### PR TITLE
Add two sum-product update rules for the Bernoulli factor node

### DIFF
--- a/src/engines/julia/update_rules/bernoulli.jl
+++ b/src/engines/julia/update_rules/bernoulli.jl
@@ -1,14 +1,20 @@
 export
 ruleSPBernoulliOutVP,
+ruleSPBernoulliIn1PV,
+ruleSPBernoulliOutVB,
 ruleVBBernoulliOut,
 ruleVBBernoulliIn1
 
 ruleSPBernoulliOutVP(msg_out::Nothing, msg_p::Message{PointMass, Univariate}) = Message(Univariate, Bernoulli, p=deepcopy(msg_p.dist.params[:m]))
 
+ruleSPBernoulliIn1PV(msg_out::Message{PointMass, Univariate}, msg_p::Nothing) = Message(Univariate, Beta, a=msg_out.dist.params[:m]+1, b=2-msg_out.dist.params[:m])
+
+ruleSPBernoulliOutVB(msg_out::Nothing, msg_p::Message{Beta, Univariate}) = Message(Univariate, Bernoulli, p=msg_p.dist.params[:a]/(msg_p.dist.params[:a] + msg_p.dist.params[:b]))
+
 function ruleVBBernoulliOut(marg_out::Any, marg_p::ProbabilityDistribution{Univariate})
     rho_1 = clamp(exp(unsafeLogMean(marg_p)), tiny, huge)
     rho_2 = clamp(exp(unsafeMirroredLogMean(marg_p)), tiny, huge)
-    
+
     Message(Univariate, Bernoulli, p=rho_1/(rho_1 + rho_2))
 end
 

--- a/src/update_rules/bernoulli.jl
+++ b/src/update_rules/bernoulli.jl
@@ -3,6 +3,16 @@
                 :inbound_types => (Nothing, Message{PointMass}),
                 :name          => SPBernoulliOutVP)
 
+@sumProductRule(:node_type     => Bernoulli,
+                :outbound_type => Message{Beta},
+                :inbound_types => (Message{PointMass}, Nothing),
+                :name          => SPBernoulliIn1PV)
+
+@sumProductRule(:node_type     => Bernoulli,
+                :outbound_type => Message{Bernoulli},
+                :inbound_types => (Nothing, Message{Beta}),
+                :name          => SPBernoulliOutVB)
+
 @naiveVariationalRule(:node_type     => Bernoulli,
                       :outbound_type => Message{Bernoulli},
                       :inbound_types => (Nothing, ProbabilityDistribution),

--- a/test/factor_nodes/test_bernoulli.jl
+++ b/test/factor_nodes/test_bernoulli.jl
@@ -3,7 +3,7 @@ module BernoulliTest
 using Test
 using ForneyLab
 import ForneyLab: outboundType, isApplicable, prod!, unsafeMean, unsafeVar, vague, dims
-import ForneyLab: SPBernoulliOutVP, VBBernoulliOut, VBBernoulliIn1
+import ForneyLab: SPBernoulliOutVP, SPBernoulliIn1PV, SPBernoulliOutVB, VBBernoulliOut, VBBernoulliIn1
 
 @testset "Bernoulli ProbabilityDistribution and Message construction" begin
     @test ProbabilityDistribution(Univariate, Bernoulli, p=0.2) == ProbabilityDistribution{Univariate, Bernoulli}(Dict(:p=>0.2))
@@ -40,9 +40,25 @@ end
 @testset "SPBernoulliOutVP" begin
     @test SPBernoulliOutVP <: SumProductRule{Bernoulli}
     @test outboundType(SPBernoulliOutVP) == Message{Bernoulli}
-    @test isApplicable(SPBernoulliOutVP, [Nothing, Message{PointMass}]) 
+    @test isApplicable(SPBernoulliOutVP, [Nothing, Message{PointMass}])
 
-    @test ruleSPBernoulliOutVP(nothing, Message(Univariate, PointMass, m=0.2)) == Message(Univariate, Bernoulli, p=0.2)
+    @test ruleSPBernoulliOutVP(nothing, Message(Univariate, PointMass, m=1.0)) == Message(Univariate, Bernoulli, p=1.0)
+end
+
+@testset "SPBernoulliIn1PV" begin
+    @test SPBernoulliIn1PV <: SumProductRule{Bernoulli}
+    @test outboundType(SPBernoulliIn1PV) == Message{Beta}
+    @test isApplicable(SPBernoulliIn1PV, [Message{PointMass}, Nothing])
+
+    @test ruleSPBernoulliIn1PV(Message(Univariate, PointMass, m=1.0), nothing) == Message(Univariate, Beta, a=2.0, b=1.0)
+end
+
+@testset "SPBernoulliOutVB" begin
+    @test SPBernoulliOutVB <: SumProductRule{Bernoulli}
+    @test outboundType(SPBernoulliOutVB) == Message{Bernoulli}
+    @test isApplicable(SPBernoulliOutVB, [Nothing, Message{Beta}])
+
+    @test ruleSPBernoulliOutVB(nothing, Message(Univariate, Beta, a=1.0, b=1.0)) == Message(Univariate, Bernoulli, p=0.5)
 end
 
 @testset "VBBernoulliOut" begin


### PR DESCRIPTION
Implementation of two sum-product update rules and the corresponding unit tests for the Bernoulli factor node as derived by Thijs in the "ForneyLab Derivations" document (see below). 
![image](https://user-images.githubusercontent.com/19517248/53101965-14c79200-352b-11e9-8fc0-b44c349f044f.png)
