### PR TITLE
Fixed parsing issue when initialization block is present.

### DIFF
--- a/src/engines/julia/sum_product.jl
+++ b/src/engines/julia/sum_product.jl
@@ -7,8 +7,10 @@ function sumProductAlgorithm(variables::Vector{Variable}; file::String="", name:
     schedule = sumProductSchedule(variables)
     marginal_schedule = marginalSchedule(variables)
 
-    algo = messagePassingAlgorithm(schedule, marginal_schedule, file=file, name=name)
-
+    algo = "begin\n\n"
+    algo *= messagePassingAlgorithm(schedule, marginal_schedule, file=file, name=name)
+    algo *= "\n\nend # block"
+    
     return algo
 end
 sumProductAlgorithm(variable::Variable; file::String="", name::String="") = sumProductAlgorithm([variable], file=file, name=name)


### PR DESCRIPTION
With this PR output of `sumProductAlgorithm` function becomes a single block and can be parsed by `Meta.parse` directly (see e.g. [mountain car demo](https://github.com/biaslab/ActiveInferenceExperiments/blob/master/mountain_car/mountain_car.ipynb)).