### PR TITLE
Added bibtex file with citation information for ForneyLab.jl.

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,15 @@
+@article{ForneyLab.jl-2019,
+	title = {A factor graph approach to automated design of {Bayesian} signal processing algorithms},
+	volume = {104},
+	issn = {0888-613X},
+	url = {http://www.sciencedirect.com/science/article/pii/S0888613X18304298},
+	doi = {10.1016/j.ijar.2018.11.002},
+	abstract = {The benefits of automating design cycles for Bayesian inference-based algorithms are becoming increasingly recognized by the machine learning community. As a result, interest in probabilistic programming frameworks has much increased over the past few years. This paper explores a specific probabilistic programming paradigm, namely message passing in Forney-style factor graphs (FFGs), in the context of automated design of efficient Bayesian signal processing algorithms. To this end, we developed “ForneyLab”2 as a Julia toolbox for message passing-based inference in FFGs. We show by example how ForneyLab enables automatic derivation of Bayesian signal processing algorithms, including algorithms for parameter estimation and model comparison. Crucially, due to the modular makeup of the FFG framework, both the model specification and inference methods are readily extensible in ForneyLab. In order to test this framework, we compared variational message passing as implemented by ForneyLab with automatic differentiation variational inference (ADVI) and Monte Carlo methods as implemented by state-of-the-art tools “Edward” and “Stan”. In terms of performance, extensibility and stability issues, ForneyLab appears to enjoy an edge relative to its competitors for automated inference in state-space models.},
+	urldate = {2018-11-16},
+	journal = {International Journal of Approximate Reasoning},
+	author = {Cox, Marco and van de Laar, Thijs and de Vries, Bert},
+	month = jan,
+	year = {2019},
+	keywords = {Bayesian inference, Message passing, Factor graphs, Julia, Probabilistic programming},
+	pages = {185--204}
+}


### PR DESCRIPTION
This PR adds `CITATION.bib` file with a bibtex entry for FL journal paper. While it is not being used currently, it might be used in the future in e.g. documentation tools (see [here](https://github.com/JuliaLang/julia/pull/31794) for more information).