### PR TITLE
Enforce the cholinv argument to be Hermitian

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -17,10 +17,10 @@ attempts with added regularization (1e-8*I) on failure.
 """
 function cholinv(M::AbstractMatrix)
     try
-        return inv(cholesky(M))
+        return inv(cholesky(Hermitian(M)))
     catch
         try
-            return inv(cholesky(M + 1e-8*I))
+            return inv(cholesky(Hermitian(M + 1e-8*I)))
         catch exception
             if exception == PosDefException
                 throw("PosDefException: Matrix is not positive-definite,


### PR DESCRIPTION
Due to numeric instabilities, the argument to `cholinv` might strictly not be Hermitian. Because `cholinv` is used in situations where the argument matrix is assumed Hermitian, we can enforce it to be Hermitian.