### PR TITLE
replace nonlinear local approximation with unscented transform

### DIFF
--- a/src/engines/julia/message_passing.jl
+++ b/src/engines/julia/message_passing.jl
@@ -15,7 +15,8 @@ function writeInitializationBlock(schedule::Schedule, interface_to_msg_idx::Dict
             partner = ultimatePartner(entry.interface)
             breaker_types[partner] = outbound_types[partner]
             breaker_dims[partner] = 1
-        elseif isa(entry.interface.node, Nonlinear)
+        elseif isa(entry.interface.node, Nonlinear) && (entry.interface == entry.interface.node.interfaces[2]) && (entry.interface.node.g_inv == nothing)
+            # Set initialization in case of a nonlinear node without given inverse 
             iface = ultimatePartner(entry.interface.node.interfaces[2])
             breaker_types[iface] = outbound_types[iface]
             breaker_dims[iface] = entry.interface.node.dims[1]

--- a/src/engines/julia/update_rules/nonlinear.jl
+++ b/src/engines/julia/update_rules/nonlinear.jl
@@ -71,8 +71,8 @@ function ruleSPNonlinearOutNG(msg_out::Nothing,
 
     # Unscented approximation
     g_sigma = g.(sigma_points)
-    m_fw_out = sum([weights_m[k+1]*g_sigma[k+1] for k=0:2])
-    V_fw_out = sum([weights_c[k+1]*(g_sigma[k+1] - m_fw_out)^2 for k=0:2])
+    m_fw_out = sum(weights_m.*g_sigma)
+    V_fw_out = sum(weights_c.*(g_sigma .- m_fw_out).^2)
 
     return Message(Univariate, GaussianMeanVariance, m=m_fw_out, v=V_fw_out)
 end
@@ -100,8 +100,8 @@ function ruleSPNonlinearIn1GG(msg_out::Message{F, Univariate},
 
     # Unscented approximation
     g_inv_sigma = g_inv.(sigma_points)
-    m_bw_in1 = sum([weights_m[k+1]*g_inv_sigma[k+1] for k=0:2])
-    V_bw_in1 = sum([weights_c[k+1]*(g_inv_sigma[k+1] - m_bw_in1)^2 for k=0:2])
+    m_bw_in1 = sum(weights_m.*g_inv_sigma)
+    V_bw_in1 = sum(weights_c.*(g_inv_sigma .- m_bw_in1).^2)
 
     return Message(Univariate, GaussianMeanVariance, m=m_bw_in1, v=V_bw_in1)
 end
@@ -132,9 +132,9 @@ function ruleSPNonlinearIn1GG(msg_out::Message{F1, Univariate},
 
     # Unscented approximations
     g_sigma = g.(sigma_points)
-    m_fw_out = sum([weights_m[k+1]*g_sigma[k+1] for k=0:2])
-    V_fw_out = sum([weights_c[k+1]*(g_sigma[k+1] - m_fw_out)^2 for k=0:2])
-    C_fw = sum([weights_c[k+1]*(sigma_points[k+1] - m_fw_in1)*(g_sigma[k+1] - m_fw_out) for k=0:2])
+    m_fw_out = sum(weights_m.*g_sigma)
+    V_fw_out = sum(weights_c.*(g_sigma .- m_fw_out).^2)
+    C_fw = sum(weights_c.*(sigma_points .- m_fw_in1).*(g_sigma .- m_fw_out))
 
     # Update based on (Petersen et al. 2018; On Approximate Nonlinear Gaussian Message Passing on Factor Graphs)
     C_fw_inv = 1/C_fw

--- a/src/engines/julia/update_rules/nonlinear.jl
+++ b/src/engines/julia/update_rules/nonlinear.jl
@@ -1,87 +1,173 @@
 export
 ruleSPNonlinearOutNG,
-ruleSPNonlinearIn1GN
+ruleSPNonlinearIn1GG
 
 
 """
-Find a local linear approximation to the nonlinear vector function g at x_hat
+Return the sigma points and weights for a Gaussian distribution
 """
-function approximate(x_hat::Union{T, Vector{T}} where T <: Number, g::Function, J_g::Function)
-    A = J_g(x_hat)
-    b = g(x_hat) .- A*x_hat
+function sigmaPointsAndWeights(dist::ProbabilityDistribution{Univariate, F}) where F<:Gaussian
+    (m_x, V_x) = unsafeMeanCov(dist)
 
-    return (A, b)
+    kappa = 0
+    alpha = 1e-3
+    beta = 2
+    lambda = (1 + kappa)*alpha^2 - 1
+
+    sigma_points = Vector{Float64}(undef, 3)
+    weights_m = Vector{Float64}(undef, 3)
+    weights_c = Vector{Float64}(undef, 3)
+
+    l = sqrt((1 + lambda)*V_x)
+
+    sigma_points[1] = m_x
+    sigma_points[2] = m_x + l
+    sigma_points[3] = m_x - l
+    weights_m[1] = lambda/(1 + lambda)
+    weights_m[2] = weights_m[3] = 1/(2*(1 + lambda))
+    weights_c[1] = weights_m[1] + (1 - alpha^2 + beta)
+    weights_c[2] = weights_c[3] = 1/(2*(1 + lambda))
+
+    return (sigma_points, weights_m, weights_c)
 end
 
-function ruleSPNonlinearOutNG(  msg_out::Nothing,
-                                msg_in1::Message{F, Multivariate},
-                                g::Function,
-                                J_g::Function,
-                                g_inv::Union{Function, Nothing}=nothing) where F<:Gaussian
+function sigmaPointsAndWeights(dist::ProbabilityDistribution{Multivariate, F}) where F<:Gaussian
+    d = dims(dist)
+    (m_x, V_x) = unsafeMeanCov(dist)
 
-    d_in1 = convert(ProbabilityDistribution{Multivariate, GaussianMeanVariance}, msg_in1.dist)
+    kappa = 0
+    alpha = 1e-3
+    beta = 2
+    lambda = (d + kappa)*alpha^2 - d
 
-    (A, b) = approximate(d_in1.params[:m], g, J_g)
-    V_q = A*d_in1.params[:v]*A'
-    V_q = V_q + tiny*diageye(size(V_q)[1]) # Ensure V_q is invertible
+    sigma_points = Vector{Vector{Float64}}(undef, 2*d+1)
+    weights_m = Vector{Float64}(undef, 2*d+1)
+    weights_c = Vector{Float64}(undef, 2*d+1)
 
-    Message(Multivariate, GaussianMeanVariance, m=A*d_in1.params[:m] + b, v=V_q)
-end
-
-function ruleSPNonlinearOutNG(  msg_out::Nothing,
-                                msg_in1::Message{F, Univariate},
-                                g::Function,
-                                J_g::Function,
-                                g_inv::Union{Function, Nothing}=nothing) where F<:Gaussian
-
-    d_in1 = convert(ProbabilityDistribution{Univariate, GaussianMeanVariance}, msg_in1.dist)
-
-    (a, b) = approximate(d_in1.params[:m], g, J_g)
-    v_q = clamp(d_in1.params[:v]*a^2, tiny, huge)
-
-    Message(Univariate, GaussianMeanVariance, m=a*d_in1.params[:m] + b, v=v_q)
-end
-
-function ruleSPNonlinearIn1GN(  msg_out::Message{F, Multivariate},
-                                msg_in1::Message, # Any type of message, used for determining the approximation point
-                                g::Function,
-                                J_g::Function,
-                                g_inv::Union{Function, Nothing}=nothing) where F<:Gaussian
-
-    d_out = convert(ProbabilityDistribution{Multivariate, GaussianMeanPrecision}, msg_out.dist)
-
-    if (g_inv != nothing)
-        x_hat = g_inv(unsafeMean(msg_out.dist))
+    if isa(V_x, Diagonal)
+        L = sqrt((d + lambda)*V_x) # Matrix square root
     else
-        x_hat = unsafeMean(msg_in1.dist)
+        L = sqrt(Hermitian((d + lambda)*V_x))
     end
 
-    (A, b) = approximate(x_hat, g, J_g)
-    A_inv = pinv(A)
-    W_q = A'*d_out.params[:w]*A
-    W_q = W_q + tiny*diageye(size(W_q)[1]) # Ensure W_q is invertible
+    sigma_points[1] = m_x
+    weights_m[1] = lambda/(d + lambda)
+    weights_c[1] = weights_m[1] + (1 - alpha^2 + beta)
+    for i = 1:d
+        sigma_points[2*i] = m_x + L[:,i]
+        sigma_points[2*i+1] = m_x - L[:,i]
+    end
+    weights_m[2:end] .= 1/(2*(d + lambda))
+    weights_c[2:end] .= 1/(2*(d + lambda))
 
-    Message(Multivariate, GaussianMeanPrecision, m=A_inv*(d_out.params[:m] - b), w=W_q)
+    return (sigma_points, weights_m, weights_c)
 end
 
-function ruleSPNonlinearIn1GN(  msg_out::Message{F, Univariate},
-                                msg_in1::Message, # Any type of message, used for determining the approximation point
-                                g::Function,
-                                J_g::Function,
-                                g_inv::Union{Function, Nothing}=nothing) where F<:Gaussian
+function ruleSPNonlinearOutNG(msg_out::Nothing,
+                              msg_in1::Message{F, Univariate},
+                              g::Function) where F<:Gaussian
 
-    d_out = convert(ProbabilityDistribution{Univariate, GaussianMeanPrecision}, msg_out.dist)
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(msg_in1.dist)
 
-    if (g_inv != nothing)
-        x_hat = g_inv(unsafeMean(msg_out.dist))
-    else
-        x_hat = unsafeMean(msg_in1.dist)
-    end
+    # Unscented approximation
+    g_sigma = g.(sigma_points)
+    m_fw_out = sum([weights_m[k+1]*g_sigma[k+1] for k=0:2])
+    V_fw_out = sum([weights_c[k+1]*(g_sigma[k+1] - m_fw_out)^2 for k=0:2])
 
-    (a, b) = approximate(x_hat, g, J_g)
-    w_q = clamp(d_out.params[:w]*a^2, tiny, huge)
+    return Message(Univariate, GaussianMeanVariance, m=m_fw_out, v=V_fw_out)
+end
 
-    Message(Univariate, GaussianMeanPrecision, m=(d_out.params[:m] - b)/a, w=w_q)
+function ruleSPNonlinearOutNG(msg_out::Nothing,
+                              msg_in1::Message{F, Multivariate},
+                              g::Function) where F<:Gaussian
+    d = dims(msg_in1.dist)
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(msg_in1.dist)
+
+    # Unscented approximation
+    g_sigma = g.(sigma_points)
+    m_fw_out = sum([weights_m[k+1]*g_sigma[k+1] for k=0:2*d])
+    V_fw_out = sum([weights_c[k+1]*(g_sigma[k+1] - m_fw_out)*(g_sigma[k+1] - m_fw_out)' for k=0:2*d])
+
+    return Message(Multivariate, GaussianMeanVariance, m=m_fw_out, v=V_fw_out)
+end
+
+function ruleSPNonlinearIn1GG(msg_out::Message{F, Univariate},
+                              msg_in1::Nothing,
+                              g::Function,
+                              g_inv::Function) where F<:Gaussian
+
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(msg_out.dist)
+
+    # Unscented approximation
+    g_inv_sigma = g_inv.(sigma_points)
+    m_bw_in1 = sum([weights_m[k+1]*g_inv_sigma[k+1] for k=0:2])
+    V_bw_in1 = sum([weights_c[k+1]*(g_inv_sigma[k+1] - m_bw_in1)^2 for k=0:2])
+
+    return Message(Univariate, GaussianMeanVariance, m=m_bw_in1, v=V_bw_in1)
+end
+
+function ruleSPNonlinearIn1GG(msg_out::Message{F, Multivariate},
+                              msg_in1::Nothing,
+                              g::Function,
+                              g_inv::Function) where F<:Gaussian
+    d = dims(msg_out.dist)
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(msg_out.dist)
+
+    # Unscented approximation
+    g_inv_sigma = g_inv.(sigma_points)
+    m_bw_in1 = sum([weights_m[k+1]*g_inv_sigma[k+1] for k=0:2*d])
+    V_bw_in1 = sum([weights_c[k+1]*(g_inv_sigma[k+1] - m_bw_in1)*(g_inv_sigma[k+1] - m_bw_in1)' for k=0:2*d])
+
+    return Message(Multivariate, GaussianMeanVariance, m=m_bw_in1, v=V_bw_in1)
+end
+
+function ruleSPNonlinearIn1GG(msg_out::Message{F1, Univariate},
+                              msg_in1::Message{F2, Univariate},
+                              g::Function) where {F1<:Gaussian, F2<:Gaussian}
+
+    (m_fw_in1, V_fw_in1) = unsafeMeanCov(msg_in1.dist)
+    (m_bw_out, V_bw_out) = unsafeMeanCov(msg_out.dist)
+
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(msg_in1.dist)
+
+    # Unscented approximations
+    g_sigma = g.(sigma_points)
+    m_fw_out = sum([weights_m[k+1]*g_sigma[k+1] for k=0:2])
+    V_fw_out = sum([weights_c[k+1]*(g_sigma[k+1] - m_fw_out)^2 for k=0:2])
+    C_fw = sum([weights_c[k+1]*(sigma_points[k+1] - m_fw_in1)*(g_sigma[k+1] - m_fw_out) for k=0:2])
+
+    # Update based on (Petersen et al. 2018; On Approximate Nonlinear Gaussian Message Passing on Factor Graphs)
+    C_fw_inv = 1/C_fw
+    V_bw_in1 = V_fw_in1^2*C_fw_inv^2*(V_fw_out + V_bw_out) - V_fw_in1
+    m_bw_in1 = m_fw_in1 - (V_fw_in1 + V_bw_in1)*C_fw*(m_fw_out - m_bw_out)/(V_fw_in1*(V_fw_out + V_bw_out))
+
+    return Message(Univariate, GaussianMeanVariance, m=m_bw_in1, v=V_bw_in1)
+end
+
+function ruleSPNonlinearIn1GG(msg_out::Message{F1, Multivariate},
+                              msg_in1::Message{F2, Multivariate},
+                              g::Function) where {F1<:Gaussian, F2<:Gaussian}
+    d_in1 = dims(msg_in1.dist)
+
+    (m_fw_in1, V_fw_in1) = unsafeMeanCov(msg_in1.dist)
+    W_fw_in1 = unsafePrecision(msg_in1.dist)
+    (m_bw_out, V_bw_out) = unsafeMeanCov(msg_out.dist)
+
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(msg_in1.dist)
+
+    # Unscented approximations
+    g_sigma = g.(sigma_points)
+    m_fw_out = sum([weights_m[k+1]*g_sigma[k+1] for k=0:2*d_in1])
+    V_fw_out = sum([weights_c[k+1]*(g_sigma[k+1] - m_fw_out)*(g_sigma[k+1] - m_fw_out)' for k=0:2*d_in1])
+    C_fw = sum([weights_c[k+1]*(sigma_points[k+1] - m_fw_in1)*(g_sigma[k+1] - m_fw_out)' for k=0:2*d_in1])
+
+    # Update based on (Petersen et al. 2018; On Approximate Nonlinear Gaussian Message Passing on Factor Graphs)
+    # Note, this implementation is not as efficient as Petersen et al. (2018), because we explicitly require the outbound messages
+    C_fw_inv = pinv(C_fw)
+    V_bw_in1 = V_fw_in1*C_fw_inv'*(V_fw_out + V_bw_out)*C_fw_inv*V_fw_in1 - V_fw_in1
+    m_bw_in1 = m_fw_in1 - (V_fw_in1 + V_bw_in1)*W_fw_in1*C_fw*cholinv(V_fw_out + V_bw_out)*(m_fw_out - m_bw_out)
+
+    return Message(Multivariate, GaussianMeanVariance, m=m_bw_in1, v=V_bw_in1)
 end
 
 
@@ -93,9 +179,8 @@ function collectSumProductNodeInbounds(node::Nonlinear, entry::ScheduleEntry, in
     inbound_messages = String[]
     for node_interface in node.interfaces
         inbound_interface = ultimatePartner(node_interface)
-        if node_interface == node.interfaces[2]
-            # Always collect the message inbound on the in1 edge,
-            # because it is used to obtain the approximation point
+        if (node_interface == entry.interface == node.interfaces[2]) && (node.g_inv == nothing)
+            # Collect the message inbound on the out edge if no inverse is available
             haskey(interface_to_msg_idx, inbound_interface) || error("The nonlinear node's backward rule uses the incoming message on the input edge to determine the approximation point. Try altering the variable order in the scheduler to first perform a forward pass.")
             inbound_idx = interface_to_msg_idx[inbound_interface]
             push!(inbound_messages, "messages[$inbound_idx]")
@@ -112,11 +197,10 @@ function collectSumProductNodeInbounds(node::Nonlinear, entry::ScheduleEntry, in
         end
     end
 
-    # Push function and Jacobi matrix function names to calling signature
-    # These functions need to be defined in the scope of the user
+    # Push function (and inverse) to calling signature
+    # These functions needs to be defined in the scope of the user
     push!(inbound_messages, "$(node.g)")
-    push!(inbound_messages, "$(node.J_g)")
-    if (node.g_inv != nothing)
+    if (entry.interface == node.interfaces[2]) && (node.g_inv != nothing)
         push!(inbound_messages, "$(node.g_inv)")
     end
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -22,10 +22,10 @@ function cholinv(M::AbstractMatrix)
         try
             return inv(cholesky(Hermitian(M + 1e-8*I)))
         catch exception
-            if exception == PosDefException
-                throw("PosDefException: Matrix is not positive-definite,
-                      even after regularization")
+            if isa(exception, PosDefException)
+                error("PosDefException: Matrix is not positive-definite, even after regularization. $(typeof(M)):\n$M")
             else
+                println("Error for $(typeof(M)):\n$M")
                 rethrow(exception)
             end
         end

--- a/src/update_rules/nonlinear.jl
+++ b/src/update_rules/nonlinear.jl
@@ -4,6 +4,6 @@
                 :name          => SPNonlinearOutNG)
 
 @sumProductRule(:node_type     => Nonlinear,
-                :outbound_type => Message{GaussianMeanPrecision},
+                :outbound_type => Message{GaussianMeanVariance},
                 :inbound_types => (Message{Gaussian}, Nothing),
-                :name          => SPNonlinearIn1GN)
+                :name          => SPNonlinearIn1GG)

--- a/test/factor_nodes/test_nonlinear.jl
+++ b/test/factor_nodes/test_nonlinear.jl
@@ -2,57 +2,96 @@ module NonlinearTest
 
 using Test
 using ForneyLab
-import ForneyLab: approximate, outboundType, isApplicable
-import ForneyLab: SPNonlinearOutNG, SPNonlinearIn1GN
+import ForneyLab: outboundType, isApplicable, sigmaPointsAndWeights
+import ForneyLab: SPNonlinearOutNG, SPNonlinearIn1GG
 
-g_a(x) = x.^2 - 5.0
-g_prime_a(x) = 2*x
+@testset "sigmaPointsAndWeights" begin
+    dist = ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(dist)
+    @test sigma_points == [0.0, 0.0010000000000143778, -0.0010000000000143778]
+    @test weights_m == [-999998.9999712444, 499999.9999856222, 499999.9999856222]
+    @test weights_c == [-999995.9999722444, 499999.9999856222, 499999.9999856222]
 
-g_b(x) = 2.0*x[1].^2 + 2.0*x[2].^2 + x[1]*x[2] - 5.0
-J_g_b(x) = [4.0*x[1] + x[2] 4.0*x[2] + x[1]]
-
-g_c(x) = [x[1]*x[2], x[1] + x[2]]
-J_g_c(x) = [x[2] x[1]; 1.0 1.0]
-
-@testset "approximate" begin
-    # g: R -> R
-    x_hat = 2.0
-    @test ForneyLab.approximate(x_hat, g_a, g_prime_a) == (4.0, -9.0)
-
-    # g: R^2 -> R
-    x_hat = [2.0, 2.0]
-    @test ForneyLab.approximate(x_hat, g_b, J_g_b) == ([10.0 10.0], [-25.0])
-
-    # g: R^2 -> R^2
-    x_hat = [2.0, 2.0]
-    @test ForneyLab.approximate(x_hat, g_c, J_g_c) == ([2.0 2.0; 1.0 1.0], [-4.0, 0.0])
+    dist = ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.0], v=mat(1.0))
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(dist)
+    @test sigma_points == [[0.0], [0.0010000000000143778], [-0.0010000000000143778]]
+    @test weights_m == [-999998.9999712444, 499999.9999856222, 499999.9999856222]
+    @test weights_c == [-999995.9999722444, 499999.9999856222, 499999.9999856222]
 end
+
 
 #-------------
 # Update rules
 #-------------
 
 g(x::Float64) = x^2 - 5.0
-J_g(x::Float64) = 2*x
 g(x::Vector{Float64}) = x.^2 .- 5.0
-J_g(x::Vector{Float64}) = reshape(2*x, 1, 1)
+g_inv(x::Float64) = sqrt(x + 5.0)
+g_inv(x::Vector{Float64}) = sqrt.(x .+ 5.0)
 
 @testset "SPNonlinearOutNG" begin
     @test SPNonlinearOutNG <: SumProductRule{Nonlinear}
     @test outboundType(SPNonlinearOutNG) == Message{GaussianMeanVariance}
     @test isApplicable(SPNonlinearOutNG, [Nothing, Message{Gaussian}]) 
 
-    @test ruleSPNonlinearOutNG(nothing, Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), g, J_g) == Message(Univariate, GaussianMeanVariance, m=-1.0, v=48.0)
-    @test ruleSPNonlinearOutNG(nothing, Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), g, J_g) == Message(Multivariate, GaussianMeanVariance, m=[-1.0], v=mat(48.0 + tiny))
+    @test ruleSPNonlinearOutNG(nothing, Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), g) == Message(Univariate, GaussianMeanVariance, m=2.0000000001164153, v=66.00000000093132)
+    @test ruleSPNonlinearOutNG(nothing, Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), g) == Message(Multivariate, GaussianMeanVariance, m=[2.0000000001164153], v=mat(66.00000000093132))
 end
 
-@testset "SPNonlinearIn1GN" begin
-    @test SPNonlinearIn1GN <: SumProductRule{Nonlinear}
-    @test outboundType(SPNonlinearIn1GN) == Message{GaussianMeanPrecision}
-    @test isApplicable(SPNonlinearIn1GN, [Message{Gaussian}, Nothing]) 
+@testset "SPNonlinearIn1GG" begin
+    @test SPNonlinearIn1GG <: SumProductRule{Nonlinear}
+    @test outboundType(SPNonlinearIn1GG) == Message{GaussianMeanVariance}
+    @test isApplicable(SPNonlinearIn1GG, [Message{Gaussian}, Nothing]) 
 
-    @test ruleSPNonlinearIn1GN(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), Message(Univariate, PointMass, m=2.0), g, J_g) == Message(Univariate, GaussianMeanPrecision, m=0.25*(2.0 + 9.0), w=1.0/(0.25*3.0*0.25))
-    @test ruleSPNonlinearIn1GN(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), Message(Multivariate, PointMass, m=[2.0]), g, J_g) == Message(Multivariate, GaussianMeanPrecision, m=[0.25*(2.0 + 9.0)], w=mat(1.0/(0.25*3.0*0.25) + tiny))
+    # Without given inverse
+    @test ruleSPNonlinearIn1GG(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), Message(Univariate, GaussianMeanVariance, m=2.0, v=1.0), g) == Message(Univariate, GaussianMeanVariance, m=2.499999999868301, v=0.3125000002253504)
+    @test ruleSPNonlinearIn1GG(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(1.0)), g) == Message(Multivariate, GaussianMeanVariance, m=[2.499999999868301], v=mat(0.31250000021807445))
+
+    # With given inverse
+    @test ruleSPNonlinearIn1GG(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), nothing, g, g_inv) == Message(Univariate, GaussianMeanVariance, m=2.6255032138433307, v=0.10796282966583703)
+    @test ruleSPNonlinearIn1GG(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), nothing, g, g_inv) == Message(Multivariate, GaussianMeanVariance, m=[2.6255032138433307], v=mat(0.10796282966583703))
+end
+
+
+#------------
+# Integration
+#------------
+
+@testset "Nonlinear integration with given inverse" begin
+    FactorGraph()
+
+    @RV x ~ GaussianMeanVariance(2.0, 1.0)
+    @RV y ~ GaussianMeanVariance(2.0, 3.0)
+    n = Nonlinear(y, x, g, inverse=g_inv)
+
+    # Forward; g_inv should not be present in call
+    algo = sumProductAlgorithm(y)
+    @test occursin("ruleSPNonlinearOutNG(nothing, messages[2], Main.ForneyLabTest.NonlinearTest.g)", algo)
+    @test !occursin("g_inv", algo)
+
+    # Backward; g_inv should be present in call
+    algo = sumProductAlgorithm(x)
+    @test occursin("ruleSPNonlinearIn1GG(messages[2], nothing, Main.ForneyLabTest.NonlinearTest.g, Main.ForneyLabTest.NonlinearTest.g_inv)", algo)
+end
+
+@testset "Nonlinear integration without given inverse" begin
+    FactorGraph()
+
+    @RV x ~ GaussianMeanVariance(2.0, 1.0)
+    @RV y ~ GaussianMeanVariance(2.0, 3.0)
+    n = Nonlinear(y, x, g)
+
+    # Forward; g_inv should not be present in call
+    algo = sumProductAlgorithm(y)
+    @test occursin("ruleSPNonlinearOutNG(nothing, messages[2], Main.ForneyLabTest.NonlinearTest.g)", algo)
+    @test !occursin("g_inv", algo)
+
+    # Backward; g_inv should not be present in call, 
+    # both messages should be required, and initialization should take place
+    algo = sumProductAlgorithm(x)
+    @test occursin("ruleSPNonlinearIn1GG(messages[2], messages[1], Main.ForneyLabTest.NonlinearTest.g)", algo)
+    @test !occursin("g_inv", algo)
+    @test occursin("messages[1] = Message(vague(GaussianMeanVariance))", algo)
 end
 
 end # module

--- a/test/test_factor_node.jl
+++ b/test/test_factor_node.jl
@@ -31,7 +31,7 @@ import InteractiveUtils: subtypes
         elseif node_type == GaussianMixture # Required for Vararg argument
             test_node = GaussianMixture(Variable(), Variable(), Variable(), Variable(), Variable(), Variable())
         elseif node_type == Nonlinear
-            test_node = Nonlinear(Variable(), Variable(), ()->(), ()->())
+            test_node = Nonlinear(Variable(), Variable(), ()->())
         else
             constructor_argument_length = length(first(methods(node_type)).sig.parameters) - 1
             vars = [Variable() for v = 1:constructor_argument_length]

--- a/test/test_helpers.jl
+++ b/test/test_helpers.jl
@@ -2,7 +2,7 @@ module HelpersTest
 
 using Test
 import ForneyLab: ensureMatrix, isApproxEqual, isRoundedPosDef, huge, tiny, format, leaftypes, isValid, invalidate!, cholinv, diageye, *, ^
-import LinearAlgebra: Diagonal, isposdef, PosDefException, I, Hermitian
+import LinearAlgebra: Diagonal, isposdef, I, Hermitian
 
 @testset "Helpers" begin
     @testset "ensureMatrix" begin
@@ -45,7 +45,7 @@ import LinearAlgebra: Diagonal, isposdef, PosDefException, I, Hermitian
         E = [1.0 1.0+1e8; 1.0+1e8 1.0] #non-PD not due to numerical precision
         @test isApproxEqual(cholinv(B), [1.0 -1.0; -1.0 2.0])
         @test isApproxEqual(cholinv(C), D)
-        @test_throws PosDefException cholinv(E)
+        @test_throws Exception cholinv(E)
         F = Diagonal([2.0, 3.0])
         @test cholinv(F) == inv(F)
     end


### PR DESCRIPTION
Updates for the `Nonlinear` node were previously based on local linear approximations, which are inaccurate and require the Jacobi matrix. This PR replaces the local nonlinear approximations with the Unscented Transform, which has improved accuracy over local linear approximations and does not require the Jacobi matrix. Backward MP is implemented by a Rauch-Tung-Striebel smoother approach, in accordance with (Petersen et al., 2018, "On approximate Gaussian Message Passing on Factor Graphs").