### PR TITLE
Allow for alpha as optional parameter in unscented transform

### DIFF
--- a/src/factor_nodes/nonlinear.jl
+++ b/src/factor_nodes/nonlinear.jl
@@ -27,11 +27,12 @@ mutable struct Nonlinear <: DeltaFactor
 
     g::Function # Vector function that expresses the output vector as a function of the input vector; reduces to scalar for 1-d
     g_inv::Union{Function, Nothing} # Inverse of g (optional)
+    alpha::Union{Float64, Nothing} # Spread parameter for unscented transform
     dims::Tuple # Dimension of breaker message on input interface
 
-    function Nonlinear(out, in1, g::Function; g_inv=nothing, dims=(), id=ForneyLab.generateId(Nonlinear))
+    function Nonlinear(out, in1, g::Function; g_inv=nothing, alpha=nothing, dims=(), id=ForneyLab.generateId(Nonlinear))
         @ensureVariables(out, in1)
-        self = new(id, Vector{Interface}(undef, 2), Dict{Symbol,Interface}(), g, g_inv, dims)
+        self = new(id, Vector{Interface}(undef, 2), Dict{Symbol,Interface}(), g, g_inv, alpha, dims)
         ForneyLab.addNode!(currentGraph(), self)
         self.i[:out] = self.interfaces[1] = associate!(Interface(self), out)
         self.i[:in1] = self.interfaces[2] = associate!(Interface(self), in1)

--- a/test/factor_nodes/test_nonlinear.jl
+++ b/test/factor_nodes/test_nonlinear.jl
@@ -7,13 +7,13 @@ import ForneyLab: SPNonlinearOutNG, SPNonlinearIn1GG
 
 @testset "sigmaPointsAndWeights" begin
     dist = ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)
-    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(dist)
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(dist, 1e-3)
     @test sigma_points == [0.0, 0.0010000000000143778, -0.0010000000000143778]
     @test weights_m == [-999998.9999712444, 499999.9999856222, 499999.9999856222]
     @test weights_c == [-999995.9999722444, 499999.9999856222, 499999.9999856222]
 
     dist = ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.0], v=mat(1.0))
-    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(dist)
+    (sigma_points, weights_m, weights_c) = sigmaPointsAndWeights(dist, 1e-3)
     @test sigma_points == [[0.0], [0.0010000000000143778], [-0.0010000000000143778]]
     @test weights_m == [-999998.9999712444, 499999.9999856222, 499999.9999856222]
     @test weights_c == [-999995.9999722444, 499999.9999856222, 499999.9999856222]
@@ -35,7 +35,9 @@ g_inv(x::Vector{Float64}) = sqrt.(x .+ 5.0)
     @test isApplicable(SPNonlinearOutNG, [Nothing, Message{Gaussian}]) 
 
     @test ruleSPNonlinearOutNG(nothing, Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), g) == Message(Univariate, GaussianMeanVariance, m=2.0000000001164153, v=66.00000000093132)
+    @test ruleSPNonlinearOutNG(nothing, Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), g, alpha=1.0) == Message(Univariate, GaussianMeanVariance, m=2.0, v=66.0)
     @test ruleSPNonlinearOutNG(nothing, Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), g) == Message(Multivariate, GaussianMeanVariance, m=[2.0000000001164153], v=mat(66.00000000093132))
+    @test ruleSPNonlinearOutNG(nothing, Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), g, alpha=1.0) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(66.0))
 end
 
 @testset "SPNonlinearIn1GG" begin
@@ -45,11 +47,15 @@ end
 
     # Without given inverse
     @test ruleSPNonlinearIn1GG(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), Message(Univariate, GaussianMeanVariance, m=2.0, v=1.0), g) == Message(Univariate, GaussianMeanVariance, m=2.499999999868301, v=0.3125000002253504)
+    @test ruleSPNonlinearIn1GG(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), Message(Univariate, GaussianMeanVariance, m=2.0, v=1.0), g, alpha=1.0) == Message(Univariate, GaussianMeanVariance, m=2.5, v=0.3125)
     @test ruleSPNonlinearIn1GG(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(1.0)), g) == Message(Multivariate, GaussianMeanVariance, m=[2.499999999868301], v=mat(0.31250000021807445))
+    @test ruleSPNonlinearIn1GG(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(1.0)), g, alpha=1.0) == Message(Multivariate, GaussianMeanVariance, m=[2.5], v=mat(0.3125))
 
     # With given inverse
     @test ruleSPNonlinearIn1GG(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), nothing, g, g_inv) == Message(Univariate, GaussianMeanVariance, m=2.6255032138433307, v=0.10796282966583703)
+    @test ruleSPNonlinearIn1GG(Message(Univariate, GaussianMeanVariance, m=2.0, v=3.0), nothing, g, g_inv, alpha=1.0) == Message(Univariate, GaussianMeanVariance, m=2.6251028535207217, v=0.10968772603524787)
     @test ruleSPNonlinearIn1GG(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), nothing, g, g_inv) == Message(Multivariate, GaussianMeanVariance, m=[2.6255032138433307], v=mat(0.10796282966583703))
+    @test ruleSPNonlinearIn1GG(Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(3.0)), nothing, g, g_inv, alpha=1.0) == Message(Multivariate, GaussianMeanVariance, m=[2.6251028535207217], v=mat(0.10968772603524787))
 end
 
 
@@ -72,6 +78,18 @@ end
     # Backward; g_inv should be present in call
     algo = sumProductAlgorithm(x)
     @test occursin("ruleSPNonlinearIn1GG(messages[2], nothing, Main.ForneyLabTest.NonlinearTest.g, Main.ForneyLabTest.NonlinearTest.g_inv)", algo)
+end
+
+@testset "Nonlinear integration with given alpha" begin
+    FactorGraph()
+
+    @RV x ~ GaussianMeanVariance(2.0, 1.0)
+    @RV y ~ GaussianMeanVariance(2.0, 3.0)
+    n = Nonlinear(y, x, g, alpha=1.0)
+
+    # Forward; alpha should be present in call
+    algo = sumProductAlgorithm(y)
+    @test occursin("ruleSPNonlinearOutNG(nothing, messages[2], Main.ForneyLabTest.NonlinearTest.g, alpha=1.0)", algo)
 end
 
 @testset "Nonlinear integration without given inverse" begin


### PR DESCRIPTION
The alpha parameter for the unscented transform in the nonlinear node is previously fixed to a small value (1e-3). This PR allows for overriding this default setting, which may be desirable in some applications; e.g. see [this post](https://nbviewer.jupyter.org/github/sbitzer/UKF-exposed/blob/master/UKF.ipynb) by Sebastian Bitzer.