### PR TITLE
Extra check for input message types for isApplicable

### DIFF
--- a/src/algorithms/expectation_propagation/expectation_propagation.jl
+++ b/src/algorithms/expectation_propagation/expectation_propagation.jl
@@ -183,7 +183,8 @@ macro expectationPropagationRule(fields...)
     end
 
     # Build validators for isApplicable
-    input_type_validators = String[]
+    input_type_validators = 
+        String["length(input_types) == $(length(inbound_types.args))"]
     for (i, i_type) in enumerate(inbound_types.args)
         if i_type != :Nothing
             # Only validate inbounds required for message update

--- a/src/algorithms/sum_product/sum_product.jl
+++ b/src/algorithms/sum_product/sum_product.jl
@@ -160,7 +160,8 @@ macro sumProductRule(fields...)
     end
 
     # Build validators for isApplicable
-    input_type_validators = String[]
+    input_type_validators = 
+        String["length(input_types) == $(length(inbound_types.args))"]
     for (i, i_type) in enumerate(inbound_types.args)
         if i_type != :Nothing
             # Only validate inbounds required for message update

--- a/src/algorithms/variational_bayes/joint_marginals.jl
+++ b/src/algorithms/variational_bayes/joint_marginals.jl
@@ -138,7 +138,8 @@ macro marginalRule(fields...)
     end
 
     # Build validators for isApplicable
-    input_type_validators = String[]
+    input_type_validators = 
+        String["length(input_types) == $(length(inbound_types.args))"]
     for (i, i_type) in enumerate(inbound_types.args)
         if i_type != :Nothing
             # Only validate inbounds required for update

--- a/src/algorithms/variational_bayes/naive_variational_bayes.jl
+++ b/src/algorithms/variational_bayes/naive_variational_bayes.jl
@@ -127,7 +127,8 @@ macro naiveVariationalRule(fields...)
     end
 
     # Build validators for isApplicable
-    input_type_validators = String[]
+    input_type_validators = 
+        String["length(input_types) == $(length(inbound_types.args))"]
     for (i, i_type) in enumerate(inbound_types.args)
         if i_type != :Nothing
             # Only validate inbounds required for message update

--- a/src/algorithms/variational_bayes/structured_variational_bayes.jl
+++ b/src/algorithms/variational_bayes/structured_variational_bayes.jl
@@ -105,7 +105,8 @@ macro structuredVariationalRule(fields...)
     end
 
     # Build validators for isApplicable
-    input_type_validators = String[]
+    input_type_validators = 
+        String["length(input_types) == $(length(inbound_types.args))"]
     for (i, i_type) in enumerate(inbound_types.args)
         if i_type != :Nothing
             # Only validate inbounds required for message update

--- a/test/algorithms/expectation_propagation/test_expectation_propagation.jl
+++ b/test/algorithms/expectation_propagation/test_expectation_propagation.jl
@@ -32,6 +32,8 @@ end
 
 @testset "@expectationPropagationRule" begin
     @test EPMockIn1GP <: ExpectationPropagationRule{MockNode}
+    @test isApplicable(EPMockIn1GP, [Message{PointMass}, Message{Gaussian}], 2)
+    @test !isApplicable(EPMockIn1GP, [Message{PointMass}, Message{Gaussian}, Message{Gaussian}], 2)
 end
 
 @testset "inferUpdateRule!" begin

--- a/test/algorithms/sum_product/test_sum_product.jl
+++ b/test/algorithms/sum_product/test_sum_product.jl
@@ -31,6 +31,8 @@ end
 
 @testset "@SumProductRule" begin
     @test SPMockOutPP <: SumProductRule{MockNode}
+    @test isApplicable(SPMockOutPP, [Nothing, Message{PointMass}, Message{PointMass}])
+    @test !isApplicable(SPMockOutPP, [Nothing, Message{PointMass}, Message{PointMass}, Message{PointMass}])    
 end
 
 # Composite definition for inferUpdateRule! testset

--- a/test/algorithms/variational_bayes/test_joint_marginals.jl
+++ b/test/algorithms/variational_bayes/test_joint_marginals.jl
@@ -30,6 +30,8 @@ end
 
 @testset "@marginalRule" begin
     @test MMockPPD <: MarginalRule{MockNode}
+    @test isApplicable(MMockPPD, [Message{PointMass}, Message{PointMass}, ProbabilityDistribution])
+    @test !isApplicable(MMockPPD, [Message{PointMass}, Message{PointMass}, ProbabilityDistribution, ProbabilityDistribution])    
 end
 
 @testset "inferMarginalRule" begin

--- a/test/algorithms/variational_bayes/test_naive_variational_bayes.jl
+++ b/test/algorithms/variational_bayes/test_naive_variational_bayes.jl
@@ -31,6 +31,8 @@ end
 
 @testset "@naiveVariationalRule" begin
     @test VBMockOut <: NaiveVariationalRule{MockNode}
+    @test isApplicable(VBMockOut, [Nothing, ProbabilityDistribution, ProbabilityDistribution])
+    @test !isApplicable(VBMockOut, [Nothing, ProbabilityDistribution, ProbabilityDistribution, ProbabilityDistribution])    
 end
 
 @testset "inferUpdateRule!" begin

--- a/test/algorithms/variational_bayes/test_structured_variational_bayes.jl
+++ b/test/algorithms/variational_bayes/test_structured_variational_bayes.jl
@@ -43,6 +43,8 @@ end
     @test SVBMock1VGD <: StructuredVariationalRule{MockNode}
     @test SVBMock2GVD <: StructuredVariationalRule{MockNode}
     @test SVBMock3DV <: StructuredVariationalRule{MockNode}
+    @test isApplicable(SVBMock1VGD, [Nothing, Message{PointMass}, ProbabilityDistribution])
+    @test !isApplicable(SVBMock1VGD, [Nothing, Message{PointMass}, ProbabilityDistribution, ProbabilityDistribution])    
 end
 
 @testset "inferUpdateRule!" begin


### PR DESCRIPTION
This PR fixes a bug in code generation for `isApplicable` function for structured variational message passing.

When we define two rules that differ in the number of arguments, e.g.

```julia
function ruleOne(d1::T1, d2::T2, d3::T3)
...
function ruleTwo(d1::T1, d2::T2, d3::T3, d4::T4)
```

Generated function for `isApplicable(::Type{ruleTwo}, input_types::Vector{<:Type})` will return `true` for `input_types = [T1, T2, T3]`, which is incorrect. In my understanding situation like this can only occur in structured variational message passing. If that is not the case, same validator should be added to the other macros that define update rules.