### PR TITLE
Make `neighbours::Vector{LinkedList{Int}}` 

### DIFF
--- a/src/dependency_graph.jl
+++ b/src/dependency_graph.jl
@@ -69,7 +69,7 @@ Dependency graphs are used for example by message scheduling algorithms.
 """
 mutable struct DependencyGraph{VT}
     vertices::Vector{VT}
-    neighbors::Vector{LinkedList}
+    neighbors::Vector{LinkedList{Int}}
 
     DependencyGraph{VT}() where VT = new(Vector{VT}(), Vector{LinkedList{Int}}())
 end


### PR DESCRIPTION
`neighbours`  are already constrained to `::Vector{LinkedList{Int}}` per the constructor
```
DependencyGraph{VT}() where VT = new(Vector{VT}(), Vector{LinkedList{Int}}())
end
```

This gives a bit more info to Julia's optimiser, but I don't know if it makes a big difference in practice.