### PR TITLE
Explicitly reshape singleton matrices upon code generation

### DIFF
--- a/src/engines/julia/generators.jl
+++ b/src/engines/julia/generators.jl
@@ -261,8 +261,13 @@ Convert a value to parseable Julia code
 valueSourceCode(val::Union{Vector, Number}) = string(val)
 valueSourceCode(val::Diagonal) = "Diagonal($(val.diag))"
 function valueSourceCode(val::AbstractMatrix)
-    if size(val) == (1,1)
-        val_code = "mat($(val[1]))"
+    # If the dimensionality in at least one direction is 1, a matrix needs to be
+    # constructed explicitly; otherwise the output Julia code will construct a vector.
+    d = size(val)
+    if d == (1,1)
+        val_code = "mat($(val[1]))" # Shorthand notation for a (1,1) matrix reshape
+    elseif 1 in d
+        val_code = "reshape($(vec(val)), $d)" # Explicit reshape
     else
         val_code = string(val)
     end

--- a/test/engines/julia/test_generators.jl
+++ b/test/engines/julia/test_generators.jl
@@ -13,6 +13,7 @@ end
     @test valueSourceCode(1) == "1"
     @test valueSourceCode([1]) == "[1]"
     @test valueSourceCode(mat(1)) == "mat(1)"
+    @test valueSourceCode(reshape([1,2,3], 3, 1)) == "reshape([1, 2, 3], (3, 1))"
     @test valueSourceCode([1 2; 2 1]) == "[1 2; 2 1]"
     @test valueSourceCode(Diagonal([1])) == "Diagonal([1])"
 end


### PR DESCRIPTION
Resolves #89; a singleton matrix needs to be explicitly reshaped upon code generation.