### PR TITLE
Regression fix for the `@RV` macro

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -171,6 +171,7 @@ end
 
 # FORM 3: @RV x
 rv_isa_form3(expr::Symbol) = true
+rv_isa_form3(expr::Expr)   = expr.head === :ref
 rv_isa_form3(expr)         = false
 
 function rv_form3(def, target, node, options)

--- a/test/test_variable.jl
+++ b/test/test_variable.jl
@@ -133,6 +133,14 @@ end
     @test g.variables[:x_new] === x
     @test length(g.variables) == 2
 
+    # @RV without node definition should create a new Variable with a given index
+    g = FactorGraph()
+    xi = Vector{Variable}(undef, 1)
+    t = 1
+    @RV xi[t]
+    @test isa(xi[1], Variable)
+    @test g.variables[:xi_1] === xi[1]
+
     # @RV should throw an exception on incorrect usage
     @test_throws ErrorException @RV 1
     @test_throws ErrorException @RV [ 1 ]


### PR DESCRIPTION
Regression fix for the `@RV` after macro refactoring.
Previously it was possible to use `@RV` macro with index and without a node definition, like
```
@RV xi[t]
```
This functionality has been broken accidentally after refactoring. 
This PR fixes regression. Additional tests added for this case.