### PR TITLE
Add rule for multiplication node

### DIFF
--- a/src/engines/julia/update_rules/multiplication.jl
+++ b/src/engines/julia/update_rules/multiplication.jl
@@ -63,6 +63,18 @@ end
 ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, msg_a::Message{PointMass, Multivariate}) where F<:Gaussian =
     ruleSPMultiplicationOutNPG(nothing, msg_a, msg_in1)
 
+function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
+                                    msg_in1::Nothing,
+                                    msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
+
+    d_out = convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, msg_out.dist)
+
+    A = msg_a.dist.params[:m]
+    W = A'*d_out.params[:w]*A
+
+    Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
+end
+
 function ruleSPMultiplicationOutNGP(msg_out::Nothing,
                                     msg_in1::Message{F, Multivariate},
                                     msg_a::Message{PointMass, Univariate}) where F<:Gaussian
@@ -102,18 +114,6 @@ function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
     W = W + tiny*diageye(size(W)[1]) # Ensure precision is always invertible
 
     Message(Multivariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
-end
-
-function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
-                                    msg_in1::Nothing,
-                                    msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
-
-    d_out = convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, msg_out.dist)
-
-    A = msg_a.dist.params[:m]
-    W = A'*d_out.params[:w]*A
-
-    Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
 end
 
 ruleSPMultiplicationOutNPP(msg_out::Nothing, msg_in1::Message{PointMass, Multivariate}, msg_a::Message{PointMass, MatrixVariate}) =

--- a/src/engines/julia/update_rules/multiplication.jl
+++ b/src/engines/julia/update_rules/multiplication.jl
@@ -112,7 +112,7 @@ function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
 
     A = msg_a.dist.params[:m]
     W = A'*d_out.params[:w]*A
-    println(Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W))
+
     Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
 end
 

--- a/src/engines/julia/update_rules/multiplication.jl
+++ b/src/engines/julia/update_rules/multiplication.jl
@@ -20,7 +20,7 @@ function ruleSPMultiplicationOutNPG(msg_out::Nothing,
     Message(Univariate, GaussianMeanVariance, m=msg_in1.dist.params[:m]*d_a.params[:m], v=d_a.params[:v]*msg_in1.dist.params[:m]^2)
 end
 
-ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, msg_a::Message{PointMass, Univariate}) where F<:Gaussian = 
+ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, msg_a::Message{PointMass, Univariate}) where F<:Gaussian =
     ruleSPMultiplicationOutNPG(nothing, msg_a, msg_in1)
 
 function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Univariate},
@@ -28,22 +28,22 @@ function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Univariate},
                                     msg_a::Message{PointMass, Univariate}) where F<:Gaussian
 
     d_out = convert(ProbabilityDistribution{Univariate, GaussianWeightedMeanPrecision}, msg_out.dist)
-    
+
     a = msg_a.dist.params[:m]
 
     Message(Univariate, GaussianWeightedMeanPrecision, xi=a*d_out.params[:xi], w=d_out.params[:w]*a^2)
 end
 
-ruleSPMultiplicationAGPN(msg_out::Message{F, Univariate}, msg_in1::Message{PointMass, Univariate}, msg_a::Nothing) where F<:Gaussian = 
+ruleSPMultiplicationAGPN(msg_out::Message{F, Univariate}, msg_in1::Message{PointMass, Univariate}, msg_a::Nothing) where F<:Gaussian =
     ruleSPMultiplicationIn1GNP(msg_out, nothing, msg_in1)
 
-ruleSPMultiplicationOutNPP(msg_out::Nothing, msg_in1::Message{PointMass, Univariate}, msg_a::Message{PointMass, Univariate}) = 
+ruleSPMultiplicationOutNPP(msg_out::Nothing, msg_in1::Message{PointMass, Univariate}, msg_a::Message{PointMass, Univariate}) =
     Message(Univariate, PointMass, m=msg_in1.dist.params[:m]*msg_a.dist.params[:m])
 
-ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Univariate}, msg_in1::Nothing, msg_a::Message{PointMass, Univariate}) = 
+ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Univariate}, msg_in1::Nothing, msg_a::Message{PointMass, Univariate}) =
     Message(Univariate, PointMass, m=msg_out.dist.params[:m]/msg_a.dist.params[:m])
 
-ruleSPMultiplicationAPPN(msg_out::Message{PointMass, Univariate}, msg_in1::Message{PointMass, Univariate}, msg_a::Nothing) = 
+ruleSPMultiplicationAPPN(msg_out::Message{PointMass, Univariate}, msg_in1::Message{PointMass, Univariate}, msg_a::Nothing) =
     Message(Univariate, PointMass, m=msg_out.dist.params[:m]/msg_in1.dist.params[:m])
 
 
@@ -60,11 +60,11 @@ function ruleSPMultiplicationOutNPG(msg_out::Nothing,
     Message(Multivariate, GaussianMeanVariance, m=msg_in1.dist.params[:m]*d_a.params[:m], v=d_a.params[:v]*msg_in1.dist.params[:m]*msg_in1.dist.params[:m]')
 end
 
-ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, msg_a::Message{PointMass, Multivariate}) where F<:Gaussian = 
+ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, msg_a::Message{PointMass, Multivariate}) where F<:Gaussian =
     ruleSPMultiplicationOutNPG(nothing, msg_a, msg_in1)
 
-function ruleSPMultiplicationOutNGP(msg_out::Nothing, 
-                                    msg_in1::Message{F, Multivariate}, 
+function ruleSPMultiplicationOutNGP(msg_out::Nothing,
+                                    msg_in1::Message{F, Multivariate},
                                     msg_a::Message{PointMass, Univariate}) where F<:Gaussian
 
     d_in1 = convert(ProbabilityDistribution{Multivariate, GaussianMeanVariance}, msg_in1.dist)
@@ -72,7 +72,7 @@ function ruleSPMultiplicationOutNGP(msg_out::Nothing,
     Message(Multivariate, GaussianMeanVariance, m=d_in1.params[:m]*msg_a.dist.params[:m], v=d_in1.params[:v]*msg_a.dist.params[:m]^2)
 end
 
-ruleSPMultiplicationOutNPG(msg_out::Nothing, msg_in1::Message{PointMass, Univariate}, msg_a::Message{F, Multivariate}) where F<:Gaussian = 
+ruleSPMultiplicationOutNPG(msg_out::Nothing, msg_in1::Message{PointMass, Univariate}, msg_a::Message{F, Multivariate}) where F<:Gaussian =
     ruleSPMultiplicationOutNGP(nothing, msg_a, msg_in1)
 
 
@@ -104,8 +104,20 @@ function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
     Message(Multivariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
 end
 
-ruleSPMultiplicationOutNPP(msg_out::Nothing, msg_in1::Message{PointMass, Multivariate}, msg_a::Message{PointMass, MatrixVariate}) = 
+function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
+                                    msg_in1::Nothing,
+                                    msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
+
+    d_out = convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, msg_out.dist)
+
+    A = msg_a.dist.params[:m]
+    W = A'*d_out.params[:w]*A
+    println(Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W))
+    Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
+end
+
+ruleSPMultiplicationOutNPP(msg_out::Nothing, msg_in1::Message{PointMass, Multivariate}, msg_a::Message{PointMass, MatrixVariate}) =
     Message(Multivariate, PointMass, m=msg_a.dist.params[:m]*msg_in1.dist.params[:m])
 
-ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Multivariate}, msg_in1::Nothing, msg_a::Message{PointMass, MatrixVariate}) = 
+ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Multivariate}, msg_in1::Nothing, msg_a::Message{PointMass, MatrixVariate}) =
     Message(Multivariate, PointMass, m=pinv(msg_a.dist.params[:m])*msg_out.dist.params[:m])

--- a/src/engines/julia/update_rules/multiplication.jl
+++ b/src/engines/julia/update_rules/multiplication.jl
@@ -7,6 +7,7 @@ ruleSPMultiplicationIn1PNP,
 ruleSPMultiplicationAGPN,
 ruleSPMultiplicationAPPN
 
+
 #-------------------------------
 # Univariate (in1 and a commute)
 #-------------------------------
@@ -47,47 +48,6 @@ ruleSPMultiplicationAPPN(msg_out::Message{PointMass, Univariate}, msg_in1::Messa
     Message(Univariate, PointMass, m=msg_out.dist.params[:m]/msg_in1.dist.params[:m])
 
 
-#--------------------------------------------
-# Univariate*multivariate (in1 and a commute)
-#--------------------------------------------
-
-function ruleSPMultiplicationOutNPG(msg_out::Nothing,
-                                    msg_in1::Message{PointMass, Multivariate},
-                                    msg_a::Message{F, Univariate}) where F<:Gaussian
-
-    d_a = convert(ProbabilityDistribution{Univariate, GaussianMeanVariance}, msg_a.dist)
-
-    Message(Multivariate, GaussianMeanVariance, m=msg_in1.dist.params[:m]*d_a.params[:m], v=d_a.params[:v]*msg_in1.dist.params[:m]*msg_in1.dist.params[:m]')
-end
-
-ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, msg_a::Message{PointMass, Multivariate}) where F<:Gaussian =
-    ruleSPMultiplicationOutNPG(nothing, msg_a, msg_in1)
-
-function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
-                                    msg_in1::Nothing,
-                                    msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
-
-    d_out = convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, msg_out.dist)
-
-    A = msg_a.dist.params[:m]
-    W = A'*d_out.params[:w]*A
-
-    Message(Univariate, GaussianWeightedMeanPrecision, xi=A'*d_out.params[:xi], w=W)
-end
-
-function ruleSPMultiplicationOutNGP(msg_out::Nothing,
-                                    msg_in1::Message{F, Multivariate},
-                                    msg_a::Message{PointMass, Univariate}) where F<:Gaussian
-
-    d_in1 = convert(ProbabilityDistribution{Multivariate, GaussianMeanVariance}, msg_in1.dist)
-
-    Message(Multivariate, GaussianMeanVariance, m=d_in1.params[:m]*msg_a.dist.params[:m], v=d_in1.params[:v]*msg_a.dist.params[:m]^2)
-end
-
-ruleSPMultiplicationOutNPG(msg_out::Nothing, msg_in1::Message{PointMass, Univariate}, msg_a::Message{F, Multivariate}) where F<:Gaussian =
-    ruleSPMultiplicationOutNGP(nothing, msg_a, msg_in1)
-
-
 #------------------------------------------------------
 # MatrixVariate*multivariate (in1 and a do NOT commute)
 #------------------------------------------------------
@@ -121,3 +81,40 @@ ruleSPMultiplicationOutNPP(msg_out::Nothing, msg_in1::Message{PointMass, Multiva
 
 ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Multivariate}, msg_in1::Nothing, msg_a::Message{PointMass, MatrixVariate}) =
     Message(Multivariate, PointMass, m=pinv(msg_a.dist.params[:m])*msg_out.dist.params[:m])
+
+
+#------------------------
+# Univariate*multivariate
+#------------------------
+
+# We consider the following updates as a special case of the MatrixVariate*Multivariate updates.
+# Namely, Ax = y, where A ∈ R^{nx1}, x ∈ R^1, and y ∈ R^n. In this case, the matrix A
+# can be represented by a n-dimensional vector, and x by a scalar. Before computation,
+# quantities are converted to their proper dimensions (see situational sketch below).
+# 
+#     | a ~ Multivariate -> R^{nx1}
+#     v  out ~ Multivariate -> R^n
+# -->[x]-->
+# in1 ~ Univariate -> R^1
+
+function ruleSPMultiplicationOutNGP(msg_out::Nothing,
+                                    msg_in1::Message{F, Univariate},
+                                    msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
+
+    dist_in1_mult = convert(ProbabilityDistribution{Multivariate, F}, msg_in1.dist)
+    dist_a_matr = convert(ProbabilityDistribution{MatrixVariate, PointMass}, msg_a.dist)
+
+    return ruleSPMultiplicationOutNGP(nothing, Message(dist_in1_mult), Message(dist_a_matr))
+end
+
+
+function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
+                                    msg_in1::Nothing,
+                                    msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
+
+    dist_a_matr = convert(ProbabilityDistribution{MatrixVariate, PointMass}, msg_a.dist)
+    msg_in1_mult = ruleSPMultiplicationIn1GNP(msg_out, nothing, Message(dist_a_matr))
+    (dims(msg_in1_mult.dist) == 1) || error("Implicit conversion to Univariate failed for $(msg_in1_mult.dist)")
+
+    return Message(Univariate, GaussianWeightedMeanPrecision, xi=msg_in1_mult.dist.params[:xi][1], w=msg_in1_mult.dist.params[:w][1,1])
+end

--- a/src/factor_nodes/gaussian.jl
+++ b/src/factor_nodes/gaussian.jl
@@ -1,5 +1,6 @@
 export Gaussian, prod!, convert
 
+# Convert parameterizations
 function convert(::Type{ProbabilityDistribution{V, GaussianMeanPrecision}}, dist::ProbabilityDistribution{V, GaussianMeanVariance}) where V<:VariateType
     w = cholinv(dist.params[:v])
     m = deepcopy(dist.params[:m])
@@ -41,6 +42,14 @@ function convert(::Type{ProbabilityDistribution{V, GaussianWeightedMeanPrecision
 
     return ProbabilityDistribution(V, GaussianWeightedMeanPrecision, xi=xi, w=w)
 end
+
+# Convert VariateTypes
+convert(::Type{ProbabilityDistribution{Multivariate, GaussianMeanVariance}}, dist::ProbabilityDistribution{Univariate, GaussianMeanVariance}) =
+    ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[dist.params[:m]], v=mat(dist.params[:v]))
+convert(::Type{ProbabilityDistribution{Multivariate, GaussianMeanPrecision}}, dist::ProbabilityDistribution{Univariate, GaussianMeanPrecision}) =
+    ProbabilityDistribution(Multivariate, GaussianMeanPrecision, m=[dist.params[:m]], w=mat(dist.params[:w]))
+convert(::Type{ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}}, dist::ProbabilityDistribution{Univariate, GaussianWeightedMeanPrecision}) =
+    ProbabilityDistribution(Multivariate, GaussianWeightedMeanPrecision, xi=[dist.params[:xi]], w=mat(dist.params[:w]))
 
 function prod!(
     x::ProbabilityDistribution{Univariate, F1},

--- a/src/probability_distribution.jl
+++ b/src/probability_distribution.jl
@@ -117,6 +117,14 @@ isProper(dist::ProbabilityDistribution{<:VariateType, Function}) = haskey(dist.p
 
 logPdf(dist::ProbabilityDistribution{<:VariateType, Function}, x) = dist.params[:log_pdf](x)
 
+# Convert VariateTypes
+convert(::Type{ProbabilityDistribution{Multivariate, PointMass}}, dist::ProbabilityDistribution{Univariate, PointMass}) =
+    ProbabilityDistribution(Multivariate, PointMass, m=[dist.params[:m]])
+convert(::Type{ProbabilityDistribution{MatrixVariate, PointMass}}, dist::ProbabilityDistribution{Univariate, PointMass}) =
+    ProbabilityDistribution(MatrixVariate, PointMass, m=mat(dist.params[:m]))
+convert(::Type{ProbabilityDistribution{MatrixVariate, PointMass}}, dist::ProbabilityDistribution{Multivariate, PointMass}) =
+    ProbabilityDistribution(MatrixVariate, PointMass, m=reshape(dist.params[:m], dims(dist), 1))
+
 """
 Compute conditional differential entropy: H(Y|X) = H(Y, X) - H(X)
 """

--- a/test/factor_nodes/test_gaussian_mean_precision.jl
+++ b/test/factor_nodes/test_gaussian_mean_precision.jl
@@ -69,6 +69,7 @@ end
     @test convert(ProbabilityDistribution{Univariate, GaussianMeanPrecision}, ProbabilityDistribution(Univariate, GaussianMeanVariance, m=2.0, v=0.25)) == ProbabilityDistribution(Univariate, GaussianMeanPrecision, m=2.0, w=4.0)
     @test convert(ProbabilityDistribution{Multivariate, GaussianMeanPrecision}, ProbabilityDistribution(Multivariate, GaussianWeightedMeanPrecision, xi=[8.0], w=mat(4.0))) == ProbabilityDistribution(Multivariate, GaussianMeanPrecision, m=[2.0], w=mat(4.0))
     @test convert(ProbabilityDistribution{Multivariate, GaussianMeanPrecision}, ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(0.25))) == ProbabilityDistribution(Multivariate, GaussianMeanPrecision, m=[2.0], w=mat(4.0))
+    @test convert(ProbabilityDistribution{Multivariate, GaussianMeanPrecision}, ProbabilityDistribution(Univariate, GaussianMeanPrecision, m=1.0, w=2.0)) == ProbabilityDistribution(Multivariate, GaussianMeanPrecision, m=[1.0], w=mat(2.0))
 end
 
 

--- a/test/factor_nodes/test_gaussian_mean_variance.jl
+++ b/test/factor_nodes/test_gaussian_mean_variance.jl
@@ -70,6 +70,7 @@ end
     @test convert(ProbabilityDistribution{Univariate, GaussianMeanVariance}, ProbabilityDistribution(Univariate, GaussianMeanPrecision, m=2.0, w=4.0)) == ProbabilityDistribution(Univariate, GaussianMeanVariance, m=2.0, v=0.25)
     @test convert(ProbabilityDistribution{Multivariate, GaussianMeanVariance}, ProbabilityDistribution(Multivariate, GaussianWeightedMeanPrecision, xi=[8.0], w=mat(4.0))) == ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(0.25))
     @test convert(ProbabilityDistribution{Multivariate, GaussianMeanVariance}, ProbabilityDistribution(Multivariate, GaussianMeanPrecision, m=[2.0], w=mat(4.0))) == ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(0.25))
+    @test convert(ProbabilityDistribution{Multivariate, GaussianMeanVariance}, ProbabilityDistribution(Univariate, GaussianMeanVariance, m=1.0, v=2.0)) == ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[1.0], v=mat(2.0))
 end
 
 

--- a/test/factor_nodes/test_gaussian_weighted_mean_precision.jl
+++ b/test/factor_nodes/test_gaussian_weighted_mean_precision.jl
@@ -69,6 +69,7 @@ end
     @test convert(ProbabilityDistribution{Univariate, GaussianWeightedMeanPrecision}, ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.5, v=0.25)) == ProbabilityDistribution(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=4.0)
     @test convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, ProbabilityDistribution(Multivariate, GaussianMeanPrecision, m=[0.5], w=mat(4.0))) == ProbabilityDistribution(Multivariate, GaussianWeightedMeanPrecision, xi=[2.0], w=mat(4.0))
     @test convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.5], v=mat(0.25))) == ProbabilityDistribution(Multivariate, GaussianWeightedMeanPrecision, xi=[2.0], w=mat(4.0))
+    @test convert(ProbabilityDistribution{Multivariate, GaussianWeightedMeanPrecision}, ProbabilityDistribution(Univariate, GaussianWeightedMeanPrecision, xi=1.0, w=2.0)) == ProbabilityDistribution(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=mat(2.0))
 end
 
 #-------------

--- a/test/factor_nodes/test_multiplication.jl
+++ b/test/factor_nodes/test_multiplication.jl
@@ -28,7 +28,7 @@ end
 @testset "SPMultiplicationOutNGP" begin
     @test SPMultiplicationOutNGP <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationOutNGP) == Message{GaussianMeanVariance}
-    @test isApplicable(SPMultiplicationOutNGP, [Nothing, Message{Gaussian}, Message{PointMass}]) 
+    @test isApplicable(SPMultiplicationOutNGP, [Nothing, Message{Gaussian}, Message{PointMass}])
 
     @test ruleSPMultiplicationOutNGP(nothing, Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0), Message(Univariate, PointMass, m=2.0)) == Message(Univariate, GaussianMeanVariance, m=2.0, v=12.0)
     @test ruleSPMultiplicationOutNGP(nothing, Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0), Message(Multivariate, PointMass, m=[2.0])) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
@@ -39,7 +39,7 @@ end
 @testset "SPMultiplicationOutNPG" begin
     @test SPMultiplicationOutNPG <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationOutNPG) == Message{GaussianMeanVariance}
-    @test isApplicable(SPMultiplicationOutNPG, [Nothing, Message{PointMass}, Message{Gaussian}]) 
+    @test isApplicable(SPMultiplicationOutNPG, [Nothing, Message{PointMass}, Message{Gaussian}])
 
     @test ruleSPMultiplicationOutNPG(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0)) == Message(Univariate, GaussianMeanVariance, m=2.0, v=12.0)
     @test ruleSPMultiplicationOutNPG(nothing, Message(Univariate, PointMass, m=2.0), Message(Multivariate, GaussianMeanVariance, m=[1.0], v=mat(3.0))) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
@@ -49,7 +49,7 @@ end
 @testset "SPMultiplicationOutNPP" begin
     @test SPMultiplicationOutNPP <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationOutNPP) == Message{PointMass}
-    @test isApplicable(SPMultiplicationOutNPP, [Nothing, Message{PointMass}, Message{PointMass}]) 
+    @test isApplicable(SPMultiplicationOutNPP, [Nothing, Message{PointMass}, Message{PointMass}])
 
     @test ruleSPMultiplicationOutNPP(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, PointMass, m=1.0)) == Message(Univariate, PointMass, m=2.0)
     @test ruleSPMultiplicationOutNPP(nothing, Message(Multivariate, PointMass, m=[2.0]), Message(MatrixVariate, PointMass, m=mat(1.0))) == Message(Multivariate, PointMass, m=[2.0])
@@ -58,16 +58,17 @@ end
 @testset "SPMultiplicationIn1GNP" begin
     @test SPMultiplicationIn1GNP <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationIn1GNP) == Message{GaussianWeightedMeanPrecision}
-    @test isApplicable(SPMultiplicationIn1GNP, [Message{Gaussian}, Nothing, Message{PointMass}]) 
+    @test isApplicable(SPMultiplicationIn1GNP, [Message{Gaussian}, Nothing, Message{PointMass}])
 
     @test ruleSPMultiplicationIn1GNP(Message(Univariate, GaussianWeightedMeanPrecision, xi=1.0, w=3.0), nothing, Message(Univariate, PointMass, m=2.0)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
+    @test ruleSPMultiplicationIn1GNP(Message(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=mat(3.0)), nothing, Message(Multivariate, PointMass, m=[2.0])) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
     @test ruleSPMultiplicationIn1GNP(Message(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=mat(3.0)), nothing, Message(MatrixVariate, PointMass, m=mat(2.0))) == Message(Multivariate, GaussianWeightedMeanPrecision, xi=[2.0], w=mat(12.0 + tiny))
 end
 
 @testset "SPMultiplicationIn1PNP" begin
     @test SPMultiplicationIn1PNP <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationIn1PNP) == Message{PointMass}
-    @test isApplicable(SPMultiplicationIn1PNP, [Message{PointMass}, Nothing, Message{PointMass}]) 
+    @test isApplicable(SPMultiplicationIn1PNP, [Message{PointMass}, Nothing, Message{PointMass}])
 
     @test ruleSPMultiplicationIn1PNP(Message(Univariate, PointMass, m=1.0), nothing, Message(Univariate, PointMass, m=2.0)) == Message(Univariate, PointMass, m=0.5)
     @test ruleSPMultiplicationIn1PNP(Message(Multivariate, PointMass, m=[1.0]), nothing, Message(MatrixVariate, PointMass, m=mat(2.0))) == Message(Multivariate, PointMass, m=[0.5])
@@ -76,7 +77,7 @@ end
 @testset "SPMultiplicationAGPN" begin
     @test SPMultiplicationAGPN <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationAGPN) == Message{GaussianWeightedMeanPrecision}
-    @test isApplicable(SPMultiplicationAGPN, [Message{Gaussian}, Message{PointMass}, Nothing]) 
+    @test isApplicable(SPMultiplicationAGPN, [Message{Gaussian}, Message{PointMass}, Nothing])
 
     @test ruleSPMultiplicationAGPN(Message(Univariate, GaussianWeightedMeanPrecision, xi=1.0, w=3.0), Message(Univariate, PointMass, m=2.0), nothing) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
 end
@@ -84,7 +85,7 @@ end
 @testset "SPMultiplicationAPPN" begin
     @test SPMultiplicationAPPN <: SumProductRule{Multiplication}
     @test outboundType(SPMultiplicationAPPN) == Message{PointMass}
-    @test isApplicable(SPMultiplicationAPPN, [Message{PointMass}, Message{PointMass}, Nothing]) 
+    @test isApplicable(SPMultiplicationAPPN, [Message{PointMass}, Message{PointMass}, Nothing])
 
     @test ruleSPMultiplicationAPPN(Message(Univariate, PointMass, m=1.0), Message(Univariate, PointMass, m=2.0), nothing) == Message(Univariate, PointMass, m=0.5)
 end

--- a/test/factor_nodes/test_multiplication.jl
+++ b/test/factor_nodes/test_multiplication.jl
@@ -32,7 +32,6 @@ end
 
     @test ruleSPMultiplicationOutNGP(nothing, Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0), Message(Univariate, PointMass, m=2.0)) == Message(Univariate, GaussianMeanVariance, m=2.0, v=12.0)
     @test ruleSPMultiplicationOutNGP(nothing, Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0), Message(Multivariate, PointMass, m=[2.0])) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
-    @test ruleSPMultiplicationOutNGP(nothing, Message(Multivariate, GaussianMeanVariance, m=[1.0], v=mat(3.0)), Message(Univariate, PointMass, m=2.0)) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
     @test ruleSPMultiplicationOutNGP(nothing, Message(Multivariate, GaussianMeanVariance, m=[1.0], v=mat(3.0)), Message(MatrixVariate, PointMass, m=mat(2.0))) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
 end
 
@@ -42,8 +41,6 @@ end
     @test isApplicable(SPMultiplicationOutNPG, [Nothing, Message{PointMass}, Message{Gaussian}])
 
     @test ruleSPMultiplicationOutNPG(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0)) == Message(Univariate, GaussianMeanVariance, m=2.0, v=12.0)
-    @test ruleSPMultiplicationOutNPG(nothing, Message(Univariate, PointMass, m=2.0), Message(Multivariate, GaussianMeanVariance, m=[1.0], v=mat(3.0))) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
-    @test ruleSPMultiplicationOutNPG(nothing, Message(Multivariate, PointMass, m=[2.0]), Message(Univariate, GaussianMeanVariance, m=1.0, v=3.0)) == Message(Multivariate, GaussianMeanVariance, m=[2.0], v=mat(12.0))
 end
 
 @testset "SPMultiplicationOutNPP" begin
@@ -61,7 +58,7 @@ end
     @test isApplicable(SPMultiplicationIn1GNP, [Message{Gaussian}, Nothing, Message{PointMass}])
 
     @test ruleSPMultiplicationIn1GNP(Message(Univariate, GaussianWeightedMeanPrecision, xi=1.0, w=3.0), nothing, Message(Univariate, PointMass, m=2.0)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
-    @test ruleSPMultiplicationIn1GNP(Message(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=mat(3.0)), nothing, Message(Multivariate, PointMass, m=[2.0])) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
+    @test ruleSPMultiplicationIn1GNP(Message(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=mat(3.0)), nothing, Message(Multivariate, PointMass, m=[2.0])) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0 + tiny)
     @test ruleSPMultiplicationIn1GNP(Message(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=mat(3.0)), nothing, Message(MatrixVariate, PointMass, m=mat(2.0))) == Message(Multivariate, GaussianWeightedMeanPrecision, xi=[2.0], w=mat(12.0 + tiny))
 end
 

--- a/test/test_probability_distribution.jl
+++ b/test/test_probability_distribution.jl
@@ -71,6 +71,12 @@ end
     @test mean(point_mass) == transpose([0.0])
 end
 
+@testset "convert" begin
+    @test convert(ProbabilityDistribution{Multivariate, PointMass}, ProbabilityDistribution(Univariate, PointMass, m=1.0)) == ProbabilityDistribution(Multivariate, PointMass, m=[1.0])
+    @test convert(ProbabilityDistribution{MatrixVariate, PointMass}, ProbabilityDistribution(Univariate, PointMass, m=1.0)) == ProbabilityDistribution(MatrixVariate, PointMass, m=mat(1.0))
+    @test convert(ProbabilityDistribution{MatrixVariate, PointMass}, ProbabilityDistribution(Multivariate, PointMass, m=[1.0, 2.0])) == ProbabilityDistribution(MatrixVariate, PointMass, m=reshape([1.0, 2.0], 2, 1))
+end
+
 @testset "PointMass ProbabilityDistribution and Message construction" begin
     @test ProbabilityDistribution(Univariate, PointMass, m=0.2) == ProbabilityDistribution{Univariate, PointMass}(Dict(:m=>0.2))
     @test_throws Exception ProbabilityDistribution(Multivariate, PointMass, m=0.2)


### PR DESCRIPTION
Let us consider the scenario when we need to multiply **univariate gaussian** with **multivariate point-mass**. One example of this can be illustrated by adding a 'control' variable `u` to the first component of a state vector **`x=[x1, x2]^T`**, i.e.
<img width="400" alt="Screenshot 2020-07-16 at 15 11 46" src="https://user-images.githubusercontent.com/8931177/87674796-c990cd80-c776-11ea-809c-264d0a174983.png">
ForneyLab implements the outgoing (green) message i.e. 
```julia
function ruleSPMultiplicationOutNGP(msg_out::Nothing, msg_in1::Message{F, Univariate}, 
msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
```
However, the backward (red) message is missing.
This PR extends multiplication node by adding the backward message towards **univariate gaussian**
```julia
function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate}, msg_in1::Nothing,
msg_a::Message{PointMass, Multivariate}) where F<:Gaussian
```