### PR TITLE
Extend ruleSPMultiplicationAGPN

### DIFF
--- a/src/engines/julia/update_rules/multiplication.jl
+++ b/src/engines/julia/update_rules/multiplication.jl
@@ -91,7 +91,7 @@ ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Multivariate}, msg_in1::N
 # Namely, Ax = y, where A ∈ R^{nx1}, x ∈ R^1, and y ∈ R^n. In this case, the matrix A
 # can be represented by a n-dimensional vector, and x by a scalar. Before computation,
 # quantities are converted to their proper dimensions (see situational sketch below).
-# 
+#
 #     | a ~ Multivariate -> R^{nx1}
 #     v  out ~ Multivariate -> R^n
 # -->[x]-->
@@ -118,3 +118,5 @@ function ruleSPMultiplicationIn1GNP(msg_out::Message{F, Multivariate},
 
     return Message(Univariate, GaussianWeightedMeanPrecision, xi=msg_in1_mult.dist.params[:xi][1], w=msg_in1_mult.dist.params[:w][1,1])
 end
+
+ruleSPMultiplicationAGPN(msg_out::Message{F, Multivariate}, msg_in1::Message{PointMass, Multivariate}, msg_a::Nothing) where F<:Gaussian = ruleSPMultiplicationIn1GNP(msg_out, nothing, msg_in1)

--- a/test/factor_nodes/test_multiplication.jl
+++ b/test/factor_nodes/test_multiplication.jl
@@ -77,6 +77,7 @@ end
     @test isApplicable(SPMultiplicationAGPN, [Message{Gaussian}, Message{PointMass}, Nothing])
 
     @test ruleSPMultiplicationAGPN(Message(Univariate, GaussianWeightedMeanPrecision, xi=1.0, w=3.0), Message(Univariate, PointMass, m=2.0), nothing) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
+    @test ruleSPMultiplicationAGPN(Message(Multivariate, GaussianWeightedMeanPrecision, xi=[1.0], w=[3.0]), Message(Multivariate, PointMass, m=[2.0]), nothing) == Message(Univariate, GaussianWeightedMeanPrecision, xi=2.0, w=12.0)
 end
 
 @testset "SPMultiplicationAPPN" begin


### PR DESCRIPTION
This PR adds a rule for multiplication node:
```julia 
ruleSPMultiplicationAGPN(msg_out::Message{F, Multivariate}, msg_in1::Message{PointMass, Multivariate}, msg_a::Nothing)
```

```
    ^
    | a ~ Univariate
       out ~ Multivariate
-->[x]<--
in1 ~ Multivariate{Pointmass}
```