### PR TITLE
Plain gbd

### DIFF
--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -48,6 +48,7 @@ include("factor_nodes/log_normal.jl")
 include("factor_nodes/wishart.jl")
 include("factor_nodes/bernoulli.jl")
 include("factor_nodes/categorical.jl")
+include("factor_nodes/sample_list.jl")
 include("factor_nodes/contingency.jl")
 include("factor_nodes/transition.jl")
 include("factor_nodes/beta.jl")
@@ -59,7 +60,7 @@ include("factor_nodes/softmax.jl")
 include("factor_nodes/dot_product.jl")
 include("factor_nodes/poisson.jl")
 include("factor_nodes/nonlinear.jl")
-include("factor_nodes/sample_list.jl")
+
 
 
 

--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -4,7 +4,7 @@ using Base.Meta: parse
 using Base64: base64encode
 using LinearAlgebra: diag, det, tr, cholesky, pinv, PosDefException
 using SparseArrays: spzeros
-using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta, gamma
+using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta, gamma, loggamma
 using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr
 using InteractiveUtils: subtypes
 using Printf: @sprintf

--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -4,7 +4,7 @@ using Base.Meta: parse
 using Base64: base64encode
 using LinearAlgebra: diag, det, tr, cholesky, pinv, PosDefException
 using SparseArrays: spzeros
-using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta
+using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta, gamma
 using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr
 using InteractiveUtils: subtypes
 using Printf: @sprintf

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -10,11 +10,7 @@ function ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_
     n_samples = default_n_samples
     samples_a = sample(msg_a.dist,n_samples)
     samples_b = sample(msg_b.dist,n_samples)
-    s_list = Vector{Float64}(undef, n_samples)
-    for n=1:n_samples
-        c = ProbabilityDistribution(Univariate,Beta,a=samples_a[n],b=samples_b[n])
-        s_list[n] = sample(c)
-    end
+    s_list = betainvcdf.(samples_a, samples_b, rand(n_samples))
     w_list = ones(n_samples)/n_samples
     Message(Univariate,SampleList,s=s_list,w=w_list)
 end

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -1,16 +1,16 @@
 export
 ruleSPBetaOutNMM,
-ruleSPBetaA,
-ruleSPBetaB,
+ruleSPBetaMNM,
+ruleSPBetaMMN,
 ruleVBBetaOut
 
 ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{PointMass, Univariate}, msg_b::Message{PointMass, Univariate}) = Message(Univariate, Beta, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
 
 function ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_b::Message{F2, Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
-    n_samples = 1000
+    n_samples = default_n_samples
     samples_a = sample(msg_a.dist,n_samples)
     samples_b = sample(msg_b.dist,n_samples)
-    s_list = Vector{Float64}(undef, 1000)
+    s_list = Vector{Float64}(undef, n_samples)
     for n=1:n_samples
         c = ProbabilityDistribution(Univariate,Beta,a=samples_a[n],b=samples_b[n])
         s_list[n] = sample(c)
@@ -21,8 +21,8 @@ end
 
 #will not work for incoming function message for now. we need to write a sampler for function messages
 #1000 samples is chosen arbitrarily. Better to be defined by the user.
-function ruleSPBetaA(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Message{F2,Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
-    n_samples = 1000
+function ruleSPBetaMNM(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Message{F2,Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+    n_samples = default_n_samples
     samples_out = sample(msg_out.dist,n_samples)
     samples_b = sample(msg_b.dist,n_samples)
     logp(x,a,b) = (a-1)*log(x) + (b-1)*log(1.0-x) - loggamma(a) - loggamma(b) + loggamma(a+b)
@@ -30,8 +30,8 @@ function ruleSPBetaA(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Mes
     Message(Univariate, Function, log_pdf = (a)->logp(a))
 end
 
-function ruleSPBetaB(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univariate}, msg_b::Nothing) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
-    n_samples = 1000
+function ruleSPBetaMMN(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univariate}, msg_b::Nothing) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+    n_samples = default_n_samples
     samples_out = sample(msg_out.dist,n_samples)
     samples_a = sample(msg_a.dist,n_samples)
     logp(x,a,b) = (a-1)*log(x) + (b-1)*log(1.0-x) - loggamma(a) - loggamma(b) + loggamma(a+b)
@@ -39,6 +39,6 @@ function ruleSPBetaB(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univaria
     Message(Univariate, Function, log_pdf = (b)->logp(b))
 end
 
-ruleVBBetaOut(marg_out::Any, marg_a::ProbabilityDistribution{Univariate, PointMass}, marg_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=marg_a.params[:m], b=marg_b.params[:m])
+#ruleVBBetaOut(marg_out::Any, marg_a::ProbabilityDistribution{Univariate, PointMass}, marg_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=marg_a.params[:m], b=marg_b.params[:m])
 
 ruleVBBetaOut(marg_out::Any, dist_a::ProbabilityDistribution{Univariate}, dist_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=unsafeMean(dist_a), b=unsafeMean(dist_b))

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -17,8 +17,7 @@ function ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_
     Message(Univariate,SampleList,s=s_list,w=w_list)
 end
 
-#will not work for incoming function message for now. we need to write a sampler for function messages
-#1000 samples is chosen arbitrarily. Better to be defined by the user.
+# 1000 (default_n_samples) samples is chosen arbitrarily. Better to be defined by the user.
 function ruleSPBetaMNM(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Message{F2,Univariate}) where {F1<:FactorNode, F2<:FactorNode}
     n_samples = default_n_samples
     samples_out = sample(msg_out.dist,n_samples)

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -8,7 +8,7 @@ ruleVBBetaB
 
 ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{PointMass, Univariate}, msg_b::Message{PointMass, Univariate}) = Message(Univariate, Beta, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
 
-function ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_b::Message{F2, Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+function ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_b::Message{F2, Univariate}) where {F1<:FactorNode, F2<:FactorNode}
     n_samples = default_n_samples
     samples_a = sample(msg_a.dist,n_samples)
     samples_b = sample(msg_b.dist,n_samples)
@@ -19,7 +19,7 @@ end
 
 #will not work for incoming function message for now. we need to write a sampler for function messages
 #1000 samples is chosen arbitrarily. Better to be defined by the user.
-function ruleSPBetaMNM(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Message{F2,Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+function ruleSPBetaMNM(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Message{F2,Univariate}) where {F1<:FactorNode, F2<:FactorNode}
     n_samples = default_n_samples
     samples_out = sample(msg_out.dist,n_samples)
     samples_b = sample(msg_b.dist,n_samples)
@@ -28,7 +28,7 @@ function ruleSPBetaMNM(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::M
     Message(Univariate, Function, log_pdf = logp)
 end
 
-function ruleSPBetaMMN(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univariate}, msg_b::Nothing) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+function ruleSPBetaMMN(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univariate}, msg_b::Nothing) where {F1<:FactorNode, F2<:FactorNode}
     n_samples = default_n_samples
     samples_out = sample(msg_out.dist,n_samples)
     samples_a = sample(msg_a.dist,n_samples)

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -27,7 +27,7 @@ function ruleSPBetaMNM(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::M
     samples_b = sample(msg_b.dist,n_samples)
     logp(x,a,b) = (a-1)*log(x) + (b-1)*log(1.0-x) - loggamma(a) - loggamma(b) + loggamma(a+b)
     logp(a) = sum(logp.(samples_out,a,samples_b))/n_samples
-    Message(Univariate, Function, log_pdf = (a)->logp(a))
+    Message(Univariate, Function, log_pdf = logp)
 end
 
 function ruleSPBetaMMN(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univariate}, msg_b::Nothing) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
@@ -36,9 +36,7 @@ function ruleSPBetaMMN(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univar
     samples_a = sample(msg_a.dist,n_samples)
     logp(x,a,b) = (a-1)*log(x) + (b-1)*log(1.0-x) - loggamma(a) - loggamma(b) + loggamma(a+b)
     logp(b) = sum(logp.(samples_out,samples_a,b))/n_samples
-    Message(Univariate, Function, log_pdf = (b)->logp(b))
+    Message(Univariate, Function, log_pdf = logp)
 end
-
-#ruleVBBetaOut(marg_out::Any, marg_a::ProbabilityDistribution{Univariate, PointMass}, marg_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=marg_a.params[:m], b=marg_b.params[:m])
 
 ruleVBBetaOut(marg_out::Any, dist_a::ProbabilityDistribution{Univariate}, dist_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=unsafeMean(dist_a), b=unsafeMean(dist_b))

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -2,7 +2,9 @@ export
 ruleSPBetaOutNMM,
 ruleSPBetaMNM,
 ruleSPBetaMMN,
-ruleVBBetaOut
+ruleVBBetaOut,
+ruleVBBetaA,
+ruleVBBetaB
 
 ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{PointMass, Univariate}, msg_b::Message{PointMass, Univariate}) = Message(Univariate, Beta, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
 
@@ -35,4 +37,22 @@ function ruleSPBetaMMN(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univar
     Message(Univariate, Function, log_pdf = logp)
 end
 
-ruleVBBetaOut(marg_out::Any, dist_a::ProbabilityDistribution{Univariate}, dist_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=unsafeMean(dist_a), b=unsafeMean(dist_b))
+ruleVBBetaOut(marg_out::Any, dist_a::ProbabilityDistribution{Univariate}, dist_b::ProbabilityDistribution{Univariate}) = Message(Univariate, Beta, a=unsafeMean(dist_a), b=unsafeMean(dist_b))
+
+function ruleVBBetaA( dist_out::ProbabilityDistribution{Univariate},
+    dist_a::Any, dist_b::ProbabilityDistribution{Univariate})
+
+    logGamAsumB(a) = sum(loggamma.(a.+sample(dist_b,default_n_samples)))/default_n_samples
+    logp(a) = (a-1)*unsafeLogMean(dist_out) + logGamAsumB(a) - loggamma(a)
+
+    Message(Univariate, Function, log_pdf = logp)
+end
+
+function ruleVBBetaB( dist_out::ProbabilityDistribution{Univariate},
+    dist_a::ProbabilityDistribution{Univariate}, dist_b::Any)
+
+    logGamAsumB(b) = sum(loggamma.(b.+sample(dist_a,default_n_samples)))/default_n_samples
+    logp(b) = (b-1)*unsafeMirroredLogMean(dist_out) + logGamAsumB(b) - loggamma(b)
+
+    Message(Univariate, Function, log_pdf = logp)
+end

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -1,12 +1,12 @@
 export
-ruleSPBetaOutNPP,
+ruleSPBetaOutNMM,
 ruleSPBetaA,
 ruleSPBetaB,
 ruleVBBetaOut
 
-ruleSPBetaOutNPP(msg_out::Nothing, msg_a::Message{PointMass, Univariate}, msg_b::Message{PointMass, Univariate}) = Message(Univariate, Beta, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
+ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{PointMass, Univariate}, msg_b::Message{PointMass, Univariate}) = Message(Univariate, Beta, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
 
-function ruleSPBetaOutNPP(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_b::Message{F2, Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+function ruleSPBetaOutNMM(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_b::Message{F2, Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
     n_samples = 1000
     samples_a = sample(msg_a.dist,n_samples)
     samples_b = sample(msg_b.dist,n_samples)

--- a/src/engines/julia/update_rules/beta.jl
+++ b/src/engines/julia/update_rules/beta.jl
@@ -1,7 +1,44 @@
 export
 ruleSPBetaOutNPP,
+ruleSPBetaA,
+ruleSPBetaB,
 ruleVBBetaOut
 
 ruleSPBetaOutNPP(msg_out::Nothing, msg_a::Message{PointMass, Univariate}, msg_b::Message{PointMass, Univariate}) = Message(Univariate, Beta, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
 
+function ruleSPBetaOutNPP(msg_out::Nothing, msg_a::Message{F1, Univariate}, msg_b::Message{F2, Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+    n_samples = 1000
+    samples_a = sample(msg_a.dist,n_samples)
+    samples_b = sample(msg_b.dist,n_samples)
+    s_list = Vector{Float64}(undef, 1000)
+    for n=1:n_samples
+        c = ProbabilityDistribution(Univariate,Beta,a=samples_a[n],b=samples_b[n])
+        s_list[n] = sample(c)
+    end
+    w_list = ones(n_samples)/n_samples
+    Message(Univariate,SampleList,s=s_list,w=w_list)
+end
+
+#will not work for incoming function message for now. we need to write a sampler for function messages
+#1000 samples is chosen arbitrarily. Better to be defined by the user.
+function ruleSPBetaA(msg_out::Message{F1,Univariate}, msg_a::Nothing, msg_b::Message{F2,Univariate}) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+    n_samples = 1000
+    samples_out = sample(msg_out.dist,n_samples)
+    samples_b = sample(msg_b.dist,n_samples)
+    logp(x,a,b) = (a-1)*log(x) + (b-1)*log(1.0-x) - loggamma(a) - loggamma(b) + loggamma(a+b)
+    logp(a) = sum(logp.(samples_out,a,samples_b))/n_samples
+    Message(Univariate, Function, log_pdf = (a)->logp(a))
+end
+
+function ruleSPBetaB(msg_out::Message{F1,Univariate}, msg_a::Message{F2,Univariate}, msg_b::Nothing) where {F1<:Union{Function, FactorNode},F2<:Union{Function, FactorNode}}
+    n_samples = 1000
+    samples_out = sample(msg_out.dist,n_samples)
+    samples_a = sample(msg_a.dist,n_samples)
+    logp(x,a,b) = (a-1)*log(x) + (b-1)*log(1.0-x) - loggamma(a) - loggamma(b) + loggamma(a+b)
+    logp(b) = sum(logp.(samples_out,samples_a,b))/n_samples
+    Message(Univariate, Function, log_pdf = (b)->logp(b))
+end
+
 ruleVBBetaOut(marg_out::Any, marg_a::ProbabilityDistribution{Univariate, PointMass}, marg_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=marg_a.params[:m], b=marg_b.params[:m])
+
+ruleVBBetaOut(marg_out::Any, dist_a::ProbabilityDistribution{Univariate}, dist_b::ProbabilityDistribution{Univariate, PointMass}) = Message(Univariate, Beta, a=unsafeMean(dist_a), b=unsafeMean(dist_b))

--- a/src/engines/julia/update_rules/categorical.jl
+++ b/src/engines/julia/update_rules/categorical.jl
@@ -1,12 +1,12 @@
 export
 ruleSPCategoricalOutNP,
-ruleSPCategoricalIn1,
+ruleSPCategoricalIn1PN,
 ruleVBCategoricalOut,
 ruleVBCategoricalIn1
 
 ruleSPCategoricalOutNP(msg_out::Nothing, msg_p::Message{PointMass, Multivariate}) = Message(Univariate, Categorical, p=deepcopy(msg_p.dist.params[:m]))
 
-ruleSPCategoricalIn1(msg_out::Message{PointMass, Multivariate}, msg_p::Nothing) = Message(Multivariate, Dirichlet, a=deepcopy(msg_out.dist.params[:m]).+ 1.0)
+ruleSPCategoricalIn1PN(msg_out::Message{PointMass, Multivariate}, msg_p::Nothing) = Message(Multivariate, Dirichlet, a=deepcopy(msg_out.dist.params[:m]).+ 1.0)
 
 function ruleVBCategoricalOut(marg_out::Any, marg_p::ProbabilityDistribution{Multivariate})
     rho = clamp.(exp.(unsafeLogMean(marg_p)), tiny, Inf) # Softens the parameter

--- a/src/engines/julia/update_rules/categorical.jl
+++ b/src/engines/julia/update_rules/categorical.jl
@@ -9,13 +9,8 @@ ruleSPCategoricalOutNP(msg_out::Nothing, msg_p::Message{PointMass, Multivariate}
 ruleSPCategoricalIn1(msg_out::Message{PointMass, Multivariate}, msg_p::Nothing) = Message(Multivariate, Dirichlet, a=deepcopy(msg_out.dist.params[:m]).+ 1.0)
 
 function ruleVBCategoricalOut(marg_out::Any, marg_p::ProbabilityDistribution{Multivariate})
-<<<<<<< HEAD
     rho = clamp.(exp.(unsafeLogMean(marg_p)), tiny, Inf) # Softens the parameter
     
-=======
-    rho = clamp.(exp.(unsafeLogMean(marg_p)), tiny, huge)
-
->>>>>>> Allow inference with categorical observations
     Message(Univariate, Categorical, p=rho./sum(rho))
 end
 

--- a/src/engines/julia/update_rules/categorical.jl
+++ b/src/engines/julia/update_rules/categorical.jl
@@ -1,13 +1,21 @@
 export
 ruleSPCategoricalOutNP,
+ruleSPCategoricalIn1,
 ruleVBCategoricalOut,
 ruleVBCategoricalIn1
 
 ruleSPCategoricalOutNP(msg_out::Nothing, msg_p::Message{PointMass, Multivariate}) = Message(Univariate, Categorical, p=deepcopy(msg_p.dist.params[:m]))
 
+ruleSPCategoricalIn1(msg_out::Message{PointMass, Multivariate}, msg_p::Nothing) = Message(Multivariate, Dirichlet, a=deepcopy(msg_out.dist.params[:m]).+ 1.0)
+
 function ruleVBCategoricalOut(marg_out::Any, marg_p::ProbabilityDistribution{Multivariate})
+<<<<<<< HEAD
     rho = clamp.(exp.(unsafeLogMean(marg_p)), tiny, Inf) # Softens the parameter
     
+=======
+    rho = clamp.(exp.(unsafeLogMean(marg_p)), tiny, huge)
+
+>>>>>>> Allow inference with categorical observations
     Message(Univariate, Categorical, p=rho./sum(rho))
 end
 

--- a/src/engines/julia/update_rules/dirichlet.jl
+++ b/src/engines/julia/update_rules/dirichlet.jl
@@ -1,7 +1,12 @@
 export
 ruleSPDirichletOutNP,
-ruleVBDirichletOut
+ruleVBDirichletOut,
+ruleVBDirichletIn1
 
 ruleSPDirichletOutNP(msg_out::Nothing, msg_a::Message{PointMass, V}) where V<:VariateType = Message(V, Dirichlet, a=deepcopy(msg_a.dist.params[:m]))
 
-ruleVBDirichletOut(marg_out::Any, marg_a::ProbabilityDistribution{V, PointMass}) where V<:VariateType = Message(V, Dirichlet, a=unsafeMean(marg_a))
+ruleVBDirichletOut(marg_out::Any, marg_a::ProbabilityDistribution{V}) where V<:VariateType = Message(V, Dirichlet, a=unsafeMean(marg_a))
+
+function ruleVBDirichletIn1(marg_out::ProbabilityDistribution{Multivariate}, marg_a::Any)
+    Message(Multivariate, Function, log_pdf = (a)->sum((a.-1).*unsafeLogMean(marg_out)) - sum(loggamma.(a)) + loggamma(sum(a)))
+end

--- a/src/engines/julia/update_rules/gamma.jl
+++ b/src/engines/julia/update_rules/gamma.jl
@@ -1,8 +1,10 @@
-export 
+export
 ruleVBGammaOut,
-ruleSPGammaOutNPP
+ruleSPGammaOutNPP,
+ruleVBGammaA,
+ruleVBGammaB
 
-ruleSPGammaOutNPP(  msg_out::Nothing, 
+ruleSPGammaOutNPP(  msg_out::Nothing,
                     msg_a::Message{PointMass, Univariate},
                     msg_b::Message{PointMass, Univariate}) =
     Message(Univariate, Gamma, a=deepcopy(msg_a.dist.params[:m]), b=deepcopy(msg_b.dist.params[:m]))
@@ -11,3 +13,13 @@ ruleVBGammaOut( dist_out::Any,
                 dist_a::ProbabilityDistribution{Univariate},
                 dist_b::ProbabilityDistribution{Univariate}) =
     Message(Univariate, Gamma, a=unsafeMean(dist_a), b=unsafeMean(dist_b))
+
+ruleVBGammaA( dist_out::ProbabilityDistribution{Univariate},
+                dist_a::Any,
+                dist_b::ProbabilityDistribution{Univariate}) =
+    Message(Univariate, Function, log_pdf = (a)->a*unsafeLogMean(dist_b) + (a-1)*unsafeLogMean(dist_out) - logabsgamma(a)[1])
+
+ruleVBGammaB( dist_out::ProbabilityDistribution{Univariate},
+              dist_a::ProbabilityDistribution{Univariate},
+              dist_b::Any) =
+        Message(Univariate, Function, log_pdf = (b)->unsafeMean(dist_a)*log(b)-b*unsafeMean(dist_out))

--- a/src/engines/julia/update_rules/gamma.jl
+++ b/src/engines/julia/update_rules/gamma.jl
@@ -22,4 +22,4 @@ ruleVBGammaA( dist_out::ProbabilityDistribution{Univariate},
 ruleVBGammaB( dist_out::ProbabilityDistribution{Univariate},
               dist_a::ProbabilityDistribution{Univariate},
               dist_b::Any) =
-        Message(Univariate, Function, log_pdf = (b)->unsafeMean(dist_a)*log(b)-b*unsafeMean(dist_out))
+        Message(Univariate, Gamma, a=unsafeMean(dist_a)+1, b=unsafeMean(dist_out))

--- a/src/factor_nodes/beta.jl
+++ b/src/factor_nodes/beta.jl
@@ -97,3 +97,12 @@ function averageEnergy(::Type{Beta}, marg_out::ProbabilityDistribution{Univariat
     (marg_a.params[:m] - 1.0)*unsafeLogMean(marg_out) -
     (marg_b.params[:m] - 1.0)*unsafeMirroredLogMean(marg_out)
 end
+
+# By Stirling's approximation and Monte Carlo summation
+function averageEnergy(::Type{Beta}, marg_out::ProbabilityDistribution{Univariate}, marg_a::ProbabilityDistribution{Univariate}, marg_b::ProbabilityDistribution{Univariate})
+    unsafeMeanLogMean(marg_a) - unsafeMean(marg_a) + 0.5*(log(2*pi)-unsafeLogMean(marg_a)) +
+    unsafeMeanLogMean(marg_b) - unsafeMean(marg_b) + 0.5*(log(2*pi)-unsafeLogMean(marg_b)) -
+    (unsafeMean(marg_a)-1)*unsafeLogMean(marg_out) -
+    (unsafeMean(marg_b)-1)*unsafeMirroredLogMean(marg_out) -
+    sum(loggamma.(sample(marg_a,default_n_samples).+sample(marg_b,default_n_samples)))/default_n_samples
+end

--- a/src/factor_nodes/beta.jl
+++ b/src/factor_nodes/beta.jl
@@ -59,7 +59,7 @@ unsafeMirroredLogMean(dist::ProbabilityDistribution{Univariate, Beta}) = digamma
 
 unsafeVar(dist::ProbabilityDistribution{Univariate, Beta}) = dist.params[:a]*dist.params[:b]/((dist.params[:a] + dist.params[:b])^2*(dist.params[:a] + dist.params[:b] + 1.0))
 
-logPdf(dist::ProbabilityDistribution{Univariate, Beta}, x) = (dist.params[:a]-1)*log(x) + (dist.params[:b]-1)*log(1.0-x) - labsgamma(dist.params[:a]) - labsgamma(dist.params[:b]) + labsgamma(dist.params[:a]+dist.params[:b])
+logPdf(dist::ProbabilityDistribution{Univariate, Beta}, x) = (dist.params[:a]-1)*log(x) + (dist.params[:b]-1)*log(1.0-x) - loggamma(dist.params[:a]) - loggamma(dist.params[:b]) + loggamma(dist.params[:a]+dist.params[:b])
 
 function prod!( x::ProbabilityDistribution{Univariate, Beta},
                 y::ProbabilityDistribution{Univariate, Beta},

--- a/src/factor_nodes/categorical.jl
+++ b/src/factor_nodes/categorical.jl
@@ -111,3 +111,7 @@ end
 function averageEnergy(::Type{Categorical}, marg_out::ProbabilityDistribution, marg_p::ProbabilityDistribution{Multivariate})
     -sum(unsafeMean(marg_out).*unsafeLogMean(marg_p))
 end
+
+function averageEnergy(::Type{Categorical}, marg_out::ProbabilityDistribution{Multivariate,PointMass}, marg_p::ProbabilityDistribution{Multivariate})
+    -sum(marg_out.params[:m].*unsafeLogMean(marg_p))
+end

--- a/src/factor_nodes/dirichlet.jl
+++ b/src/factor_nodes/dirichlet.jl
@@ -144,16 +144,17 @@ function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Mult
     sum( (marg_a.params[:m] .- 1.0).*unsafeLogMean(marg_out) )
 end
 
-function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Multivariate, SampleList}, marg_a::ProbabilityDistribution{Multivariate, SampleList})
-    log_gamma_of_sum = loggamma(sum(unsafeMeanVector(marg_a)))
+function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Multivariate}, marg_a::ProbabilityDistribution{Multivariate, SampleList})
+    samples, weights = marg_a.params[:s], marg_a.params[:w]
+    S = length(weights) #number of samples
+    log_gamma_of_sum, sum_of_log_gamma = 0, 0
     
-    weighted_sum_of_log_gamma = 0.0
-    for (i, sample) in enumerate(marg_a.params[:s])
-        sample_sum = sum(loggamma.(marg_a.params[:s]))
-        weighted_sum_of_log_gamma += sample_sum*marg_a.params[:w][i]
+    for s=1:S
+        log_gamma_of_sum += weights[s]*loggamma(sum(samples[s]))
+        sum_of_log_gamma += weights[s]*sum(loggamma.(samples[s]))
     end
-    
-    return -log_gamma_of_sum + weighted_sum_of_log_gamma - 
+
+    return -log_gamma_of_sum + sum_of_log_gamma -
             sum((unsafeMeanVector(marg_a) .- 1.0).*unsafeLogMean(marg_out))
 end
 

--- a/src/factor_nodes/dirichlet.jl
+++ b/src/factor_nodes/dirichlet.jl
@@ -144,22 +144,17 @@ function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Mult
     sum( (marg_a.params[:m] .- 1.0).*unsafeLogMean(marg_out) )
 end
 
-#supposed to be marg_a::ProbabilityDistribution{Multivariate, SampleList}
-#however it throws an error when I do so
-function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Multivariate}, marg_a::ProbabilityDistribution{Multivariate})
-    logGammaSum = loggamma(sum(unsafeMeanVector(marg_a)))
-    sumLogGamma = 0
-    for i=1:length(marg_a.params[:s])
-        ssum = 0
-        for sj in marg_a.params[:s][i]
-            ssum += loggamma(sj)
-        end
-        sumLogGamma += ssum*marg_a.params[:w][i]
+function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Multivariate, SampleList}, marg_a::ProbabilityDistribution{Multivariate, SampleList})
+    log_gamma_of_sum = loggamma(sum(unsafeMeanVector(marg_a)))
+    
+    weighted_sum_of_log_gamma = 0.0
+    for (i, sample) in enumerate(marg_a.params[:s])
+        sample_sum = sum(loggamma.(marg_a.params[:s]))
+        weighted_sum_of_log_gamma += sample_sum*marg_a.params[:w][i]
     end
-
-    -logGammaSum +
-    sumLogGamma -
-    sum( (unsafeMeanVector(marg_a) .- 1.0).*unsafeLogMean(marg_out) )
+    
+    return -log_gamma_of_sum + weighted_sum_of_log_gamma - 
+            sum((unsafeMeanVector(marg_a) .- 1.0).*unsafeLogMean(marg_out))
 end
 
 function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{MatrixVariate}, marg_a::ProbabilityDistribution{MatrixVariate, PointMass})

--- a/src/factor_nodes/dirichlet.jl
+++ b/src/factor_nodes/dirichlet.jl
@@ -147,7 +147,7 @@ end
 function averageEnergy(::Type{Dirichlet}, marg_out::ProbabilityDistribution{Multivariate}, marg_a::ProbabilityDistribution{Multivariate, SampleList})
     samples, weights = marg_a.params[:s], marg_a.params[:w]
     S = length(weights) #number of samples
-    log_gamma_of_sum, sum_of_log_gamma = 0, 0
+    log_gamma_of_sum, sum_of_log_gamma = 0.0, 0.0
     
     for s=1:S
         log_gamma_of_sum += weights[s]*loggamma(sum(samples[s]))

--- a/src/factor_nodes/gamma.jl
+++ b/src/factor_nodes/gamma.jl
@@ -49,6 +49,9 @@ unsafeMean(dist::ProbabilityDistribution{Univariate, Gamma}) = dist.params[:a]/d
 
 unsafeLogMean(dist::ProbabilityDistribution{Univariate, Gamma}) = digamma(dist.params[:a]) - log(dist.params[:b])
 
+# https://stats.stackexchange.com/questions/457357/what-is-the-expected-value-of-x-logx-of-the-gamma-distribution
+unsafeMeanLogMean(dist::ProbabilityDistribution{Univariate, Gamma}) =  (gamma(dist.params[:a]+1)/(gamma(dist.params[:a])*dist.params[:b])) * (digamma(dist.params[:a]+1) - log(dist.params[:b]))
+
 unsafeVar(dist::ProbabilityDistribution{Univariate, Gamma}) = dist.params[:a]/dist.params[:b]^2 # unsafe variance
 
 logPdf(dist::ProbabilityDistribution{Univariate, Gamma}, x) = dist.params[:a]*log(dist.params[:b]) - labsgamma(dist.params[:a]) + (dist.params[:a]-1)*log(x) - dist.params[:b]*x
@@ -90,5 +93,13 @@ function averageEnergy(::Type{Gamma}, marg_out::ProbabilityDistribution{Univaria
     labsgamma(marg_a.params[:m]) -
     marg_a.params[:m]*unsafeLogMean(marg_b) -
     (marg_a.params[:m] - 1.0)*unsafeLogMean(marg_out) +
+    unsafeMean(marg_b)*unsafeMean(marg_out)
+end
+
+# By Stirling's approximation
+function averageEnergy(::Type{Gamma}, marg_out::ProbabilityDistribution{Univariate}, marg_a::ProbabilityDistribution{Univariate}, marg_b::ProbabilityDistribution{Univariate})
+    unsafeMeanLogMean(marg_a) - unsafeMean(marg_a) + 0.5*(log(2*pi)-unsafeLogMean(marg_a)) -
+    unsafeMean(marg_a)*unsafeLogMean(marg_b) -
+    (unsafeMean(marg_a) - 1.0)*unsafeLogMean(marg_out) +
     unsafeMean(marg_b)*unsafeMean(marg_out)
 end

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -71,8 +71,6 @@ function unsafeLogMean(dist::ProbabilityDistribution{Multivariate, SampleList})
     return sum
 end
 
-unsafeMeanLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(dist.params[:s].*log.(dist.params[:s]).*dist.params[:w])
-
 # Unbiased (co)variance estimates
 function unsafeVar(dist::ProbabilityDistribution{Univariate, SampleList})
     samples = dist.params[:s]

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -61,6 +61,8 @@ unsafeMean(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = 
 
 unsafeLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(log.(dist.params[:s]).*dist.params[:w])
 
+unsafeMeanLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(dist.params[:s].*log.(dist.params[:s]).*dist.params[:w])
+
 function unsafeLogMean(dist::ProbabilityDistribution{Multivariate, SampleList})
     sum = zeros(length(dist.params[:s][1]))
     for i=1:length(dist.params[:s])

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -264,6 +264,12 @@ function bootstrap(dist_mean::ProbabilityDistribution{Multivariate, <:Gaussian},
     return [s_U[i]' *randn(d) + m for i in 1:N] # New samples
 end
 
+#Sampling from a distribution in ForneyLab returns equally weighted samples from the distribution
+#To retain the unified standard procedure, we allow sampling from SampleList not through directly returning
+#sample and weight parameters but drawing samples from the existing list of samples according to weights.
+# Inverse-transform sampling
+sample(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = sample(dist.params[:s], Weights(dist.params[:w]))    
+
 # Differential entropy for SampleList
 function differentialEntropy(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType
     haskey(dist.params, :entropy) || error("Missing entropy for SampleList; quantity is requested but not computed")

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -61,6 +61,14 @@ unsafeMean(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = 
 
 unsafeLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(log.(dist.params[:s]).*dist.params[:w])
 
+function unsafeLogMean(dist::ProbabilityDistribution{Multivariate, SampleList})
+    sum = zeros(length(dist.params[:s][1]))
+    for i=1:length(dist.params[:s])
+        sum = sum .+ log.(dist.params[:s][i]).*dist.params[:w][i]
+    end
+    return sum
+end
+
 unsafeMeanLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(dist.params[:s].*log.(dist.params[:s]).*dist.params[:w])
 
 # Unbiased (co)variance estimates

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -61,6 +61,8 @@ unsafeMean(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = 
 
 unsafeLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(log.(dist.params[:s]).*dist.params[:w])
 
+unsafeMeanLogMean(dist::ProbabilityDistribution{Univariate, SampleList}) = sum(dist.params[:s].*log.(dist.params[:s]).*dist.params[:w])
+
 # Unbiased (co)variance estimates
 function unsafeVar(dist::ProbabilityDistribution{Univariate, SampleList})
     samples = dist.params[:s]

--- a/src/probability_distribution.jl
+++ b/src/probability_distribution.jl
@@ -125,6 +125,8 @@ convert(::Type{ProbabilityDistribution{MatrixVariate, PointMass}}, dist::Probabi
 convert(::Type{ProbabilityDistribution{MatrixVariate, PointMass}}, dist::ProbabilityDistribution{Multivariate, PointMass}) =
     ProbabilityDistribution(MatrixVariate, PointMass, m=reshape(dist.params[:m], dims(dist), 1))
 
+sample(dist::ProbabilityDistribution{T, PointMass}) where T<:VariateType = deepcopy(dist.params[:m])
+
 """
 Compute conditional differential entropy: H(Y|X) = H(Y, X) - H(X)
 """

--- a/src/update_rules/beta.jl
+++ b/src/update_rules/beta.jl
@@ -1,7 +1,22 @@
+# @sumProductRule(:node_type     => Beta,
+#                 :outbound_type => Message{Beta},
+#                 :inbound_types => (Nothing, Message{PointMass}, Message{PointMass}),
+#                 :name          => SPBetaOutNPP)
+
 @sumProductRule(:node_type     => Beta,
-                :outbound_type => Message{Beta},
-                :inbound_types => (Nothing, Message{PointMass}, Message{PointMass}),
+                :outbound_type => Message{Union{Beta,SampleList}},
+                :inbound_types => (Nothing, Message, Message),
                 :name          => SPBetaOutNPP)
+
+@sumProductRule(:node_type     => Beta,
+                :outbound_type => Message{Function},
+                :inbound_types => (Message, Nothing, Message),
+                :name          => SPBetaA)
+
+@sumProductRule(:node_type     => Beta,
+                :outbound_type => Message{Function},
+                :inbound_types => (Message, Message, Nothing),
+                :name          => SPBetaB)
 
 @naiveVariationalRule(:node_type     => Beta,
                       :outbound_type => Message{Beta},

--- a/src/update_rules/beta.jl
+++ b/src/update_rules/beta.jl
@@ -17,3 +17,13 @@
                       :outbound_type => Message{Beta},
                       :inbound_types => (Nothing, ProbabilityDistribution, ProbabilityDistribution),
                       :name          => VBBetaOut)
+
+@naiveVariationalRule(:node_type     => Beta,
+                      :outbound_type => Message{Function},
+                      :inbound_types => (ProbabilityDistribution, Nothing, ProbabilityDistribution),
+                      :name          => VBBetaA)
+
+@naiveVariationalRule(:node_type     => Beta,
+                      :outbound_type => Message{Function},
+                      :inbound_types => (ProbabilityDistribution, ProbabilityDistribution, Nothing),
+                      :name          => VBBetaB)

--- a/src/update_rules/beta.jl
+++ b/src/update_rules/beta.jl
@@ -1,7 +1,7 @@
 @sumProductRule(:node_type     => Beta,
                 :outbound_type => Message{Union{Beta,SampleList}},
                 :inbound_types => (Nothing, Message, Message),
-                :name          => SPBetaOutNPP)
+                :name          => SPBetaOutNMM)
 
 @sumProductRule(:node_type     => Beta,
                 :outbound_type => Message{Function},

--- a/src/update_rules/beta.jl
+++ b/src/update_rules/beta.jl
@@ -1,8 +1,3 @@
-# @sumProductRule(:node_type     => Beta,
-#                 :outbound_type => Message{Beta},
-#                 :inbound_types => (Nothing, Message{PointMass}, Message{PointMass}),
-#                 :name          => SPBetaOutNPP)
-
 @sumProductRule(:node_type     => Beta,
                 :outbound_type => Message{Union{Beta,SampleList}},
                 :inbound_types => (Nothing, Message, Message),

--- a/src/update_rules/beta.jl
+++ b/src/update_rules/beta.jl
@@ -6,12 +6,12 @@
 @sumProductRule(:node_type     => Beta,
                 :outbound_type => Message{Function},
                 :inbound_types => (Message, Nothing, Message),
-                :name          => SPBetaA)
+                :name          => SPBetaMNM)
 
 @sumProductRule(:node_type     => Beta,
                 :outbound_type => Message{Function},
                 :inbound_types => (Message, Message, Nothing),
-                :name          => SPBetaB)
+                :name          => SPBetaMMN)
 
 @naiveVariationalRule(:node_type     => Beta,
                       :outbound_type => Message{Beta},

--- a/src/update_rules/categorical.jl
+++ b/src/update_rules/categorical.jl
@@ -3,6 +3,11 @@
                 :inbound_types => (Nothing, Message{PointMass}),
                 :name          => SPCategoricalOutNP)
 
+@sumProductRule(:node_type     => Categorical,
+                :outbound_type => Message{Dirichlet},
+                :inbound_types => (Message{PointMass}, Nothing),
+                :name          => SPCategoricalIn1)
+
 @naiveVariationalRule(:node_type     => Categorical,
                       :outbound_type => Message{Categorical},
                       :inbound_types => (Nothing, ProbabilityDistribution),

--- a/src/update_rules/categorical.jl
+++ b/src/update_rules/categorical.jl
@@ -6,7 +6,7 @@
 @sumProductRule(:node_type     => Categorical,
                 :outbound_type => Message{Dirichlet},
                 :inbound_types => (Message{PointMass}, Nothing),
-                :name          => SPCategoricalIn1)
+                :name          => SPCategoricalIn1PN)
 
 @naiveVariationalRule(:node_type     => Categorical,
                       :outbound_type => Message{Categorical},

--- a/src/update_rules/dirichlet.jl
+++ b/src/update_rules/dirichlet.jl
@@ -7,3 +7,8 @@
                       :outbound_type => Message{Dirichlet},
                       :inbound_types => (Nothing, ProbabilityDistribution),
                       :name          => VBDirichletOut)
+
+@naiveVariationalRule(:node_type     => Dirichlet,
+                      :outbound_type => Message{Function},
+                      :inbound_types => (ProbabilityDistribution, Nothing),
+                      :name          => VBDirichletIn1)

--- a/src/update_rules/gamma.jl
+++ b/src/update_rules/gamma.jl
@@ -7,3 +7,13 @@
                       :outbound_type => Message{Gamma},
                       :inbound_types => (Nothing, ProbabilityDistribution, ProbabilityDistribution),
                       :name          => VBGammaOut)
+
+@naiveVariationalRule(:node_type     => Gamma,
+                      :outbound_type => Message{Function},
+                      :inbound_types => (ProbabilityDistribution, Nothing, ProbabilityDistribution),
+                      :name          => VBGammaA)
+
+@naiveVariationalRule(:node_type     => Gamma,
+                      :outbound_type => Message{Function},
+                      :inbound_types => (ProbabilityDistribution, ProbabilityDistribution, Nothing),
+                      :name          => VBGammaB)

--- a/src/update_rules/gamma.jl
+++ b/src/update_rules/gamma.jl
@@ -14,6 +14,6 @@
                       :name          => VBGammaA)
 
 @naiveVariationalRule(:node_type     => Gamma,
-                      :outbound_type => Message{Function},
+                      :outbound_type => Message{Gamma},
                       :inbound_types => (ProbabilityDistribution, ProbabilityDistribution, Nothing),
                       :name          => VBGammaB)

--- a/test/factor_nodes/test_beta.jl
+++ b/test/factor_nodes/test_beta.jl
@@ -3,7 +3,7 @@ module BetaTest
 using Test
 using ForneyLab
 using ForneyLab: outboundType, isApplicable, prod!, unsafeMean, unsafeLogMean, unsafeMirroredLogMean, unsafeVar, vague, dims, logPdf
-using ForneyLab: SPBetaOutNPP, VBBetaOut
+using ForneyLab: SPBetaOutNPP, SPBetaA, SPBetaB, VBBetaOut
 using SpecialFunctions: digamma
 
 @testset "Beta ProbabilityDistribution and Message construction" begin
@@ -49,10 +49,27 @@ end
 
 @testset "SPBetaOutNPP" begin
     @test SPBetaOutNPP <: SumProductRule{Beta}
-    @test outboundType(SPBetaOutNPP) == Message{Beta}
+    @test outboundType(SPBetaOutNPP) == Message{Union{Beta,SampleList}}
     @test isApplicable(SPBetaOutNPP, [Nothing, Message{PointMass}, Message{PointMass}])
+    @test isApplicable(SPBetaOutNPP, [Nothing, Message{FactorNode}, Message{PointMass}])
+    @test isApplicable(SPBetaOutNPP, [Nothing, Message{PointMass}, Message])
 
     @test ruleSPBetaOutNPP(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, PointMass, m=3.0)) == Message(Univariate, Beta, a=2.0, b=3.0)
+    d = ruleSPBetaOutNPP(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, Gamma, a=300.0, b=100.0)).dist
+    @test 0.3<mean(d)<0.5
+end
+
+@testset "SPBetaA" begin
+    @test SPBetaA <: SumProductRule{Beta}
+    @test outboundType(SPBetaA) == Message{Function}
+    @test isApplicable(SPBetaA, [Message,Nothing,Message])
+end
+
+@testset "SPBetaB" begin
+    @test SPBetaB <: SumProductRule{Beta}
+    @test outboundType(SPBetaB) == Message{Function}
+    @test !isApplicable(SPBetaB, [Message,Nothing,Message])
+    @test isApplicable(SPBetaB, [Message,Message,Nothing])
 end
 
 @testset "VBBetaOut" begin

--- a/test/factor_nodes/test_beta.jl
+++ b/test/factor_nodes/test_beta.jl
@@ -3,7 +3,7 @@ module BetaTest
 using Test
 using ForneyLab
 using ForneyLab: outboundType, isApplicable, prod!, unsafeMean, unsafeLogMean, unsafeMirroredLogMean, unsafeVar, vague, dims, logPdf
-using ForneyLab: SPBetaOutNMM, SPBetaMNM, SPBetaMMN, VBBetaOut
+using ForneyLab: SPBetaOutNMM, SPBetaMNM, SPBetaMMN, VBBetaOut, VBBetaA, VBBetaB
 using SpecialFunctions: digamma
 
 @testset "Beta ProbabilityDistribution and Message construction" begin
@@ -78,6 +78,18 @@ end
     @test isApplicable(VBBetaOut, [Nothing, ProbabilityDistribution, ProbabilityDistribution])
 
     @test ruleVBBetaOut(nothing, ProbabilityDistribution(Univariate, PointMass, m=2.0), ProbabilityDistribution(Univariate, PointMass, m=3.0)) == Message(Univariate, Beta, a=2.0, b=3.0)
+end
+
+@testset "VBBetaA" begin
+    @test VBBetaA <: NaiveVariationalRule{Beta}
+    @test outboundType(VBBetaA) == Message{Function}
+    @test isApplicable(VBBetaA, [ProbabilityDistribution, Nothing, ProbabilityDistribution])
+end
+
+@testset "VBBetaB" begin
+    @test VBBetaB <: NaiveVariationalRule{Beta}
+    @test outboundType(VBBetaB) == Message{Function}
+    @test isApplicable(VBBetaB, [ProbabilityDistribution, ProbabilityDistribution, Nothing])
 end
 
 @testset "averageEnergy and differentialEntropy" begin

--- a/test/factor_nodes/test_beta.jl
+++ b/test/factor_nodes/test_beta.jl
@@ -3,7 +3,7 @@ module BetaTest
 using Test
 using ForneyLab
 using ForneyLab: outboundType, isApplicable, prod!, unsafeMean, unsafeLogMean, unsafeMirroredLogMean, unsafeVar, vague, dims, logPdf
-using ForneyLab: SPBetaOutNPP, SPBetaA, SPBetaB, VBBetaOut
+using ForneyLab: SPBetaOutNMM, SPBetaMNM, SPBetaMMN, VBBetaOut
 using SpecialFunctions: digamma
 
 @testset "Beta ProbabilityDistribution and Message construction" begin
@@ -47,29 +47,29 @@ end
 # Update rules
 #-------------
 
-@testset "SPBetaOutNPP" begin
-    @test SPBetaOutNPP <: SumProductRule{Beta}
-    @test outboundType(SPBetaOutNPP) == Message{Union{Beta,SampleList}}
-    @test isApplicable(SPBetaOutNPP, [Nothing, Message{PointMass}, Message{PointMass}])
-    @test isApplicable(SPBetaOutNPP, [Nothing, Message{FactorNode}, Message{PointMass}])
-    @test isApplicable(SPBetaOutNPP, [Nothing, Message{PointMass}, Message])
+@testset "SPBetaOutNMM" begin
+    @test SPBetaOutNMM <: SumProductRule{Beta}
+    @test outboundType(SPBetaOutNMM) == Message{Union{Beta,SampleList}}
+    @test isApplicable(SPBetaOutNMM, [Nothing, Message{PointMass}, Message{PointMass}])
+    @test isApplicable(SPBetaOutNMM, [Nothing, Message{FactorNode}, Message{PointMass}])
+    @test isApplicable(SPBetaOutNMM, [Nothing, Message{PointMass}, Message])
 
-    @test ruleSPBetaOutNPP(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, PointMass, m=3.0)) == Message(Univariate, Beta, a=2.0, b=3.0)
-    d = ruleSPBetaOutNPP(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, Gamma, a=300.0, b=100.0)).dist
+    @test ruleSPBetaOutNMM(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, PointMass, m=3.0)) == Message(Univariate, Beta, a=2.0, b=3.0)
+    d = ruleSPBetaOutNMM(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, Gamma, a=300.0, b=100.0)).dist
     @test 0.3<mean(d)<0.5
 end
 
-@testset "SPBetaA" begin
-    @test SPBetaA <: SumProductRule{Beta}
-    @test outboundType(SPBetaA) == Message{Function}
-    @test isApplicable(SPBetaA, [Message,Nothing,Message])
+@testset "SPBetaMNM" begin
+    @test SPBetaMNM <: SumProductRule{Beta}
+    @test outboundType(SPBetaMNM) == Message{Function}
+    @test isApplicable(SPBetaMNM, [Message,Nothing,Message])
 end
 
-@testset "SPBetaB" begin
-    @test SPBetaB <: SumProductRule{Beta}
-    @test outboundType(SPBetaB) == Message{Function}
-    @test !isApplicable(SPBetaB, [Message,Nothing,Message])
-    @test isApplicable(SPBetaB, [Message,Message,Nothing])
+@testset "SPBetaMMN" begin
+    @test SPBetaMMN <: SumProductRule{Beta}
+    @test outboundType(SPBetaMMN) == Message{Function}
+    @test !isApplicable(SPBetaMMN, [Message,Nothing,Message])
+    @test isApplicable(SPBetaMMN, [Message,Message,Nothing])
 end
 
 @testset "VBBetaOut" begin

--- a/test/factor_nodes/test_dirichlet.jl
+++ b/test/factor_nodes/test_dirichlet.jl
@@ -88,6 +88,7 @@ end
     # Multivariate
     @test isapprox(differentialEntropy(ProbabilityDistribution(Multivariate, Dirichlet, a=[2.0, 3.0])), averageEnergy(Dirichlet, ProbabilityDistribution(Multivariate, Dirichlet, a=[2.0, 3.0]), ProbabilityDistribution(Multivariate, PointMass, m=[2.0, 3.0])))
     @test isapprox(averageEnergy(Dirichlet, ProbabilityDistribution(Multivariate, Dirichlet, a=[4.0, 5.0]), ProbabilityDistribution(Multivariate, PointMass, m=[2.0, 3.0])), averageEnergy(Beta, ProbabilityDistribution(Univariate, Beta, a=4.0, b=5.0), ProbabilityDistribution(Univariate, PointMass, m=2.0), ProbabilityDistribution(Univariate, PointMass, m=3.0)))
+    @test isapprox(averageEnergy(Dirichlet,ProbabilityDistribution(Multivariate,Dirichlet,a=[2.0,3.0,4.0]),ProbabilityDistribution(Multivariate,SampleList,s=[[1.0,2.0,1.0],[3.,3.,1.],[2.,2.,2]],w=[0.1,0.7,0.3])),0.5093876870003795)
 
     # MatrixVariate
     @test differentialEntropy(ProbabilityDistribution(MatrixVariate, Dirichlet, a=[2.0 3.0; 4.0 5.0])) == differentialEntropy(ProbabilityDistribution(Multivariate, Dirichlet, a=[2.0, 4.0])) + differentialEntropy(ProbabilityDistribution(Multivariate, Dirichlet, a=[3.0, 5.0]))

--- a/test/factor_nodes/test_dirichlet.jl
+++ b/test/factor_nodes/test_dirichlet.jl
@@ -3,7 +3,7 @@ module DirichletTest
 using Test
 using ForneyLab
 using ForneyLab: outboundType, isApplicable, prod!, unsafeMean, unsafeLogMean, unsafeVar, vague, dims
-using ForneyLab: SPDirichletOutNP, VBDirichletOut
+using ForneyLab: SPDirichletOutNP, VBDirichletOut, VBDirichletIn1
 using SpecialFunctions: digamma
 
 @testset "Dirichlet ProbabilityDistribution and Message construction" begin
@@ -76,6 +76,12 @@ end
 
     @test ruleVBDirichletOut(nothing, ProbabilityDistribution(Multivariate, PointMass, m=[2.0, 3.0])) == Message(Multivariate, Dirichlet, a=[2.0, 3.0])
     @test ruleVBDirichletOut(nothing, ProbabilityDistribution(MatrixVariate, PointMass, m=[2.0 3.0; 4.0 5.0])) == Message(MatrixVariate, Dirichlet, a=[2.0 3.0; 4.0 5.0])
+end
+
+@testset "VBDirichletIn1" begin
+    @test VBDirichletIn1 <: NaiveVariationalRule{Dirichlet}
+    @test outboundType(VBDirichletIn1) == Message{Function}
+    @test isApplicable(VBDirichletIn1, [ProbabilityDistribution, Nothing])
 end
 
 @testset "averageEnergy and differentialEntropy" begin

--- a/test/factor_nodes/test_gamma.jl
+++ b/test/factor_nodes/test_gamma.jl
@@ -56,9 +56,11 @@ end
 
 @testset "VBGammaB" begin
     @test VBGammaB <: NaiveVariationalRule{Gamma}
-    @test outboundType(VBGammaB) == Message{Function}
+    @test outboundType(VBGammaB) == Message{Gamma}
     @test !isApplicable(VBGammaB, [Nothing, ProbabilityDistribution, ProbabilityDistribution])
-    @test isApplicable(VBGammaB, [ProbabilityDistribution, ProbabilityDistribution, Nothing]) 
+    @test isApplicable(VBGammaB, [ProbabilityDistribution, ProbabilityDistribution, Nothing])
+
+    @test ruleVBGammaB(ProbabilityDistribution(Univariate, PointMass, m=1.5), ProbabilityDistribution(Univariate, PointMass, m=3.0), nothing) == Message(Univariate, Gamma, a=4.0, b=1.5)
 end
 
 @testset "averageEnergy and differentialEntropy" begin

--- a/test/factor_nodes/test_gamma.jl
+++ b/test/factor_nodes/test_gamma.jl
@@ -3,7 +3,7 @@ module GammaTest
 using Test
 using ForneyLab
 using ForneyLab: prod!, unsafeMean, unsafeVar, outboundType, isApplicable, dims
-using ForneyLab: SPGammaOutNPP, VBGammaOut
+using ForneyLab: SPGammaOutNPP, VBGammaOut, VBGammaA, VBGammaB
 
 @testset "dims" begin
     @test dims(ProbabilityDistribution(Univariate, Gamma, a=1.0, b=1.0)) == 1
@@ -33,7 +33,7 @@ end
 @testset "SPGammaOutNPP" begin
     @test SPGammaOutNPP <: SumProductRule{Gamma}
     @test outboundType(SPGammaOutNPP) == Message{Gamma}
-    @test isApplicable(SPGammaOutNPP, [Nothing, Message{PointMass}, Message{PointMass}]) 
+    @test isApplicable(SPGammaOutNPP, [Nothing, Message{PointMass}, Message{PointMass}])
 
     @test ruleSPGammaOutNPP(nothing, Message(Univariate, PointMass, m=1.0), Message(Univariate, PointMass, m=2.0)) == Message(Univariate, Gamma, a=1.0, b=2.0)
 end
@@ -41,10 +41,24 @@ end
 @testset "VBGammaOut" begin
     @test VBGammaOut <: NaiveVariationalRule{Gamma}
     @test outboundType(VBGammaOut) == Message{Gamma}
-    @test isApplicable(VBGammaOut, [Nothing, ProbabilityDistribution, ProbabilityDistribution]) 
-    @test !isApplicable(VBGammaOut, [ProbabilityDistribution, ProbabilityDistribution, Nothing]) 
+    @test isApplicable(VBGammaOut, [Nothing, ProbabilityDistribution, ProbabilityDistribution])
+    @test !isApplicable(VBGammaOut, [ProbabilityDistribution, ProbabilityDistribution, Nothing])
 
     @test ruleVBGammaOut(nothing, ProbabilityDistribution(Univariate, PointMass, m=1.5), ProbabilityDistribution(Univariate, PointMass, m=3.0)) == Message(Univariate, Gamma, a=1.5, b=3.0)
+end
+
+@testset "VBGammaA" begin
+    @test VBGammaA <: NaiveVariationalRule{Gamma}
+    @test outboundType(VBGammaA) == Message{Function}
+    @test !isApplicable(VBGammaA, [Nothing, ProbabilityDistribution, ProbabilityDistribution])
+    @test isApplicable(VBGammaA, [ProbabilityDistribution, Nothing, ProbabilityDistribution])
+end
+
+@testset "VBGammaB" begin
+    @test VBGammaB <: NaiveVariationalRule{Gamma}
+    @test outboundType(VBGammaB) == Message{Function}
+    @test !isApplicable(VBGammaB, [Nothing, ProbabilityDistribution, ProbabilityDistribution])
+    @test isApplicable(VBGammaB, [ProbabilityDistribution, ProbabilityDistribution, Nothing]) 
 end
 
 @testset "averageEnergy and differentialEntropy" begin


### PR DESCRIPTION
This PR allows users to define priors on Gamma, Dirichlet and Beta distributions and run inference in VMP mode. Approximations (either for messages or average energies) are heavily based on Stirling's approximation and Monte Carlo summation. Missing analytical rules such as VMP towards rate of Gamma and BP for categorical node with pointmass out, has been implemented as well.