### PR TITLE
Fix #97 and implement lookup of deterministic edges prior to scheduling

### DIFF
--- a/src/algorithms/cluster.jl
+++ b/src/algorithms/cluster.jl
@@ -31,18 +31,3 @@ function region(node::FactorNode, edge::Edge)
 
     return cl::Region
 end
-
-"""
-Return the local stochastic regions around `node`
-"""
-function localStochasticRegions(node::FactorNode)
-    regions = Region[]
-    for interface in node.interfaces
-        partner = ultimatePartner(interface)
-        if !isClamped(partner) # Exclude clamped
-            push!(regions, region(node, interface.edge))
-        end
-    end
-
-    return regions
-end

--- a/src/algorithms/posterior_factorization.jl
+++ b/src/algorithms/posterior_factorization.jl
@@ -11,6 +11,7 @@ mutable struct PosteriorFactorization
     # Bookkeeping for faster lookup during scheduling
     edge_to_posterior_factor::Dict{Edge, PosteriorFactor}
     node_edge_to_cluster::Dict{Tuple{FactorNode, Edge}, Cluster}
+    deterministic_edges::Set{Edge}
 
     # Fields for assembly
     energy_counting_numbers::Dict{FactorNode, Int64}
@@ -21,8 +22,7 @@ mutable struct PosteriorFactorization
 end
 
 """
-Return currently active `PosteriorFactorization`.
-Create one if there is none.
+Return currently active `PosteriorFactorization`. Create one if there is none.
 """
 function currentPosteriorFactorization()
     try
@@ -37,32 +37,16 @@ function setCurrentPosteriorFactorization(pfz::PosteriorFactorization)
 end
 
 """
-Initialize an empty `PosteriorFactorization` for sequential construction
+Initialize an empty `PosteriorFactorization` consisting of a single `PosteriorFactor` for the entire graph
 """
-function PosteriorFactorization() 
-    setCurrentPosteriorFactorization(
-        PosteriorFactorization(
-            currentGraph(),
-            Dict{Symbol, PosteriorFactor}(),
-            Dict{Edge, PosteriorFactor}(),
-            Dict{Tuple{FactorNode, Edge}, Symbol}(),
-            Dict{FactorNode, Int64}(),
-            Dict{Region, Int64}(),
-            false
-        )
-    )
-end
-
-"""
-Construct a `PosteriorFactorization` consisting of a single `PosteriorFactor` for the entire graph
-"""
-function PosteriorFactorization(fg::FactorGraph)
+function PosteriorFactorization(fg::FactorGraph=currentGraph())
     pfz = setCurrentPosteriorFactorization(
         PosteriorFactorization(
             fg,
             Dict{Symbol, PosteriorFactor}(),
             Dict{Edge, PosteriorFactor}(),
             Dict{Tuple{FactorNode, Edge}, Symbol}(),
+            deterministicEdges(fg),
             Dict{FactorNode, Int64}(),
             Dict{Region, Int64}(),
             false
@@ -73,8 +57,7 @@ function PosteriorFactorization(fg::FactorGraph)
 end
 
 """
-Construct a `PosteriorFactorization` consisting of one
-`PosteriorFactor` for each argument
+Construct a `PosteriorFactorization` consisting of one `PosteriorFactor` for each argument
 """
 function PosteriorFactorization(args::Vararg{Union{T, Set{T}, Vector{T}} where T<:Variable}; ids=Symbol[])
     pfz = PosteriorFactorization()
@@ -119,7 +102,7 @@ function setTargets!(pf::PosteriorFactor, pfz::PosteriorFactorization; target_va
         for node in nodes_connected_to_external_edges
             isa(node, DeltaFactor) && continue # Skip deterministic nodes
 
-            target_edges = localStochasticInternalEdges(node, pf) # Find internal edges connected to node
+            target_edges = localStochasticInternalEdges(node, pf, pfz) # Find internal edges connected to node
             if length(target_edges) == 1 # Only one internal edge, the marginal for a single Variable is required
                 push!(pf.target_variables, target_edges[1].variable)
             elseif length(target_edges) > 1 # Multiple internal edges, register the region for computing the joint marginal
@@ -137,7 +120,7 @@ function setTargets!(pf::PosteriorFactor, pfz::PosteriorFactorization; target_va
         # Iterate over large regions
         nodes_connected_to_internal_edges = nodes(pf.internal_edges)
         for node in nodes_connected_to_internal_edges
-            target_edges = localStochasticInternalEdges(node, pf) # Find stochastic internal edges connected to node
+            target_edges = localStochasticInternalEdges(node, pf, pfz) # Find stochastic internal edges connected to node
             if isa(node, Clamp)
                 continue
             elseif !isa(node, DeltaFactor) # Node is stochastic
@@ -150,10 +133,12 @@ function setTargets!(pf::PosteriorFactor, pfz::PosteriorFactorization; target_va
             elseif isa(node, Equality)
                 increase!(variable_counting_numbers, target_edges[1].variable, 1) # Increase the counting number for the equality-constrained variable
             else # Node is deterministic and not Equality
-                if length(target_edges) == 2
-                    increase!(variable_counting_numbers, target_edges[2].variable, 1) # Increase counting number for variable on inbound edge
-                elseif length(target_edges) > 2
-                    region = (node, target_edges[2:end]) # Region for node and inbound edges,
+                outbound_edge = node.interfaces[1].edge
+                inbound_target_edges = filter(edge->edge!=outbound_edge, target_edges) # Vector of local internal stochastic inbound edges
+                if length(inbound_target_edges) == 1
+                    increase!(variable_counting_numbers, inbound_target_edges[1].variable, 1) # Increase counting number for variable on inbound edge
+                elseif length(inbound_target_edges) >= 2
+                    region = (node, inbound_target_edges) # Region for node and stochastic inbound edges,
                     increase!(cluster_counting_numbers, region, 1) # Increase the counting number for that region
                 end
             end
@@ -199,4 +184,35 @@ function setTargets!(pf::PosteriorFactor, pfz::PosteriorFactorization; target_va
     pfz.free_energy_flag = free_energy
 
     return pf
+end
+
+"""
+Return the local stochastic regions around `node`
+"""
+function localStochasticRegions(node::FactorNode, pfz::PosteriorFactorization)
+    regions = Region[]
+    for interface in node.interfaces
+        partner = ultimatePartner(interface)
+        if !(interface.edge in pfz.deterministic_edges) # If edge is stochastic
+            push!(regions, region(node, interface.edge))
+        end
+    end
+
+    return regions
+end
+
+"""
+Find stochastic edges that are internal to the posterior factor and connected to node.
+This function is used for constructing clusters. Therefore, the edges are returned 
+in the same order as the node's interfaces.
+"""
+function localStochasticInternalEdges(node::FactorNode, pf::PosteriorFactor, pfz::PosteriorFactorization)
+    local_internal_edges = Edge[]
+    for interface in node.interfaces
+        if (interface.edge in pf.internal_edges) && !(interface.edge in pfz.deterministic_edges) # Edge is internal to posterior factor and stochastic
+            push!(local_internal_edges, interface.edge) # Otherwise include the edge
+        end
+    end
+
+    return local_internal_edges
 end

--- a/src/engines/free_energy_assemblers.jl
+++ b/src/engines/free_energy_assemblers.jl
@@ -56,18 +56,23 @@ function assembleCountingNumbers!(pfz=currentPosteriorFactorization())
     
     # Iterate over large regions
     for node in nodes_connected_to_internal_edges
+        target_regions = unique!(localStochasticRegions(node, pfz)) # Collect all unique stochastic regions around node
         if isa(node, Clamp)
             continue
         elseif !isa(node, DeltaFactor) # Node is stochastic
             increase!(energy_counting_numbers, node, 1) # Count average energy
-            for target in unique!(localStochasticRegions(node)) # Collect all unique regions around node
+            for target in target_regions
                 increase!(entropy_counting_numbers, target, 1) # Count (joint) entropy
             end
         elseif isa(node, Equality)
             increase!(entropy_counting_numbers, node.i[1].edge.variable, 1) # Count univariate entropy
         elseif length(node.interfaces) >= 2 # Node is deterministic and not equality
-            target = region(node, node.interfaces[2].edge) # Find region of inbound edges
-            increase!(entropy_counting_numbers, target, 1) # Count (joint) entropy
+            outbound_region = region(node, node.interfaces[1].edge)
+            for target in target_regions
+                if target != outbound_region
+                    increase!(entropy_counting_numbers, target, 1) # Count (joint) entropy
+                end
+            end
         end
     end
 

--- a/src/engines/free_energy_assemblers.jl
+++ b/src/engines/free_energy_assemblers.jl
@@ -66,10 +66,10 @@ function assembleCountingNumbers!(pfz=currentPosteriorFactorization())
             end
         elseif isa(node, Equality)
             increase!(entropy_counting_numbers, node.i[1].edge.variable, 1) # Count univariate entropy
-        elseif length(node.interfaces) >= 2 # Node is deterministic and not equality
+        elseif length(node.interfaces) >= 2 # Node is deterministic and not equality, requires the counting of the joint inbounds region
             outbound_region = region(node, node.interfaces[1].edge)
             for target in target_regions
-                if target != outbound_region
+                if target != outbound_region # Exclude outbound region
                     increase!(entropy_counting_numbers, target, 1) # Count (joint) entropy
                 end
             end

--- a/src/factor_graph.jl
+++ b/src/factor_graph.jl
@@ -162,3 +162,14 @@ function ultimatePartner(interface::Interface)
         return interface.partner
     end
 end
+
+function deterministicEdges(fg::FactorGraph)
+    deterministic_edges = Set{Edge}()
+    for node in nodes(fg)
+        if isa(node, Clamp)
+            push!(deterministic_edges, node.i[:out].edge)
+        end
+    end
+
+    return deterministic_edges
+end

--- a/src/factor_graph.jl
+++ b/src/factor_graph.jl
@@ -164,16 +164,92 @@ function ultimatePartner(interface::Interface)
 end
 
 """
-Deterministic edges are associated with a PointMass distribution
+Deterministic edges are associated with a PointMass belief.
+Find all edges in the graph that are deterministic.
 """
 function deterministicEdges(fg::FactorGraph)
-    # TODO: generalize to non-clamped deterministic edges
     deterministic_edges = Set{Edge}()
     for node in nodes(fg)
         if isa(node, Clamp)
-            push!(deterministic_edges, node.i[:out].edge)
+            union!(deterministic_edges, deterministicEdgeSet(node.i[:out].edge))
         end
     end
-
+    
     return deterministic_edges
+end
+
+"""
+Extend the root_edge to a deterministically connected set, and determine
+which edges in the extended set carry PointMass beliefs.
+"""
+function deterministicEdgeSet(root_edge::Edge)
+    # Collect deterministically connected edges
+    edge_set = extend(root_edge, terminate_at_soft_factors=true)
+    
+    # Collect all interfaces in edge set
+    interfaces = Interface[]
+    for edge in edge_set
+        (edge.a == nothing) || push!(interfaces, edge.a)
+        (edge.b == nothing) || push!(interfaces, edge.b)
+    end
+    
+    # Identify a schedule that propagates through the entire edge set
+    dg = summaryDependencyGraph(edge_set)
+    schedule = children(interfaces, dg)
+
+    # Build dictionary of deterministicness
+    is_deterministic = Dict{Interface, Bool}()
+    for interface in schedule
+        is_deterministic[interface] = isDeterministic(interface, is_deterministic)
+    end
+    
+    # Determine deterministic edges
+    deterministic_edges = Set{Edge}()
+    for edge in edge_set
+        deterministic_a = (edge.a != nothing) && is_deterministic[edge.a]
+        deterministic_b = (edge.b != nothing) && is_deterministic[edge.b]
+
+        # An edge is deterministic if any of its interfaces are deterministic
+        if deterministic_a || deterministic_b
+            push!(deterministic_edges, edge)
+        end
+    end
+    
+    return deterministic_edges
+end
+
+"""
+Determine whether interface sends a PointMass message, based on the connected
+node, and the deterministic status of the inbound messages.
+"""
+function isDeterministic(interface::Interface, is_deterministic::Dict{Interface, Bool})
+    # First handle immediate cases
+    node = interface.node
+    if !isa(node, DeltaFactor)
+        # We assume a non-delta factor sends stochastic messages in all directions.
+        # This includes the CompositeFactor, for which this is the conservative choice.
+        return false
+    elseif isa(node, Clamp)
+        return true # Clamp nodes only send deterministic messages
+    end
+    
+    # Collect deterministicness of inbounds
+    inbounds_deterministic = Bool[]
+    for iface in node.interfaces
+        if iface != interface
+            partner = ultimatePartner(iface)
+            push!(inbounds_deterministic, is_deterministic[partner])
+        end
+    end
+    
+    # Determine deterministicness of outbound from inbounds
+    if isa(node, Equality) && any(inbounds_deterministic)
+        return true # Deterministic
+    elseif any(.!inbounds_deterministic)
+        return false # Delta factor with any stochastic inbounds sends a stochastic message
+    elseif all(inbounds_deterministic)
+        return true # Delta factor with all inbounds deterministic sends a deterministic message
+    else # Fallback
+        return false # Stochastic
+    end
 end

--- a/src/factor_graph.jl
+++ b/src/factor_graph.jl
@@ -163,7 +163,11 @@ function ultimatePartner(interface::Interface)
     end
 end
 
+"""
+Deterministic edges are associated with a PointMass distribution
+"""
 function deterministicEdges(fg::FactorGraph)
+    # TODO: generalize to non-clamped deterministic edges
     deterministic_edges = Set{Edge}()
     for node in nodes(fg)
         if isa(node, Clamp)

--- a/test/algorithms/test_posterior_factorization.jl
+++ b/test/algorithms/test_posterior_factorization.jl
@@ -3,7 +3,7 @@ module PosteriorFactorizationTest
 using Test
 using ForneyLab
 
-using ForneyLab: Cluster
+using ForneyLab: Cluster, deterministicEdges, deterministicEdgeSet, isDeterministic
 
 @testset "PosteriorFactorization" begin
     pfz = PosteriorFactorization()
@@ -11,6 +11,61 @@ using ForneyLab: Cluster
     @test pfz.edge_to_posterior_factor == Dict{Edge, PosteriorFactor}()
     @test pfz.node_edge_to_cluster == Dict{Tuple{FactorNode, Edge}, Cluster}()
     @test currentPosteriorFactorization() === pfz
+end
+
+@testset "isDeterministic" begin
+    # Clamp
+    fg = FactorGraph()
+    @RV x = constant(0.0)
+    @test isDeterministic(fg.nodes[:clamp_1].i[:out], Dict{Interface, Bool}())
+    
+    # Stochastic
+    fg = FactorGraph()
+    @RV x ~ GaussianMeanVariance(0.0, 1.0)
+    @test !isDeterministic(fg.nodes[:gaussianmeanvariance_1].i[:out], Dict{Interface, Bool}())
+
+    # Equality
+    fg = FactorGraph()
+    @RV x = equal(constant(0.0), constant(0.0))
+    @test isDeterministic(fg.nodes[:equality_1].i[1],
+                          Dict{Interface, Bool}(fg.nodes[:clamp_1].i[:out] => true, 
+                                                fg.nodes[:clamp_2].i[:out] => false))
+    @test !isDeterministic(fg.nodes[:equality_1].i[1],
+                           Dict{Interface, Bool}(fg.nodes[:clamp_1].i[:out] => false, 
+                                                 fg.nodes[:clamp_2].i[:out] => false))
+    # Deterministic
+    fg = FactorGraph()
+    @RV x ~ Addition(0.0, 0.0)
+    @test isDeterministic(fg.nodes[:addition_1].i[:out],
+                          Dict{Interface, Bool}(fg.nodes[:clamp_1].i[:out] => true, 
+                                                fg.nodes[:clamp_2].i[:out] => true))
+    @test !isDeterministic(fg.nodes[:addition_1].i[:out],
+                           Dict{Interface, Bool}(fg.nodes[:clamp_1].i[:out] => true, 
+                                                 fg.nodes[:clamp_2].i[:out] => false))
+end
+
+@testset "deterministicEdgeSet and deterministicEdges" begin
+    fg = FactorGraph()
+    
+    @RV x ~ GaussianMeanVariance(0.0, 1.0)
+    @RV y ~ GaussianMeanVariance(0.0, 1.0)
+    @RV w = x + y
+    @RV a = constant(1.0)
+    @RV z = a*w
+    placeholder(z, :z)
+
+    e_x = x.edges[1]
+    e_y = y.edges[1]
+    e_w = w.edges[1]
+    e_a = a.edges[1]    
+    e_z = z.edges[1]
+    e_1 = fg.nodes[:clamp_1].i[:out].edge
+    e_2 = fg.nodes[:clamp_2].i[:out].edge
+    e_3 = fg.nodes[:clamp_3].i[:out].edge
+    e_4 = fg.nodes[:clamp_4].i[:out].edge
+    
+    @test deterministicEdgeSet(e_x) == Set{Edge}([e_w, e_a, e_z])
+    @test deterministicEdges(fg) == Set{Edge}([e_w, e_a, e_z, e_1, e_2, e_3, e_4])
 end
 
 end # module


### PR DESCRIPTION
This PR fixes and includes a regression test for issue #97 . The error was caused by a bug in the tallying of the entropy counting numbers. The counting relied on interface-indexing to determine the region corresponding to the joint inbound edges. However, this method failed in case of a clamped outbound edge of a deterministic node with multiple inbounds.

Additionally, the PR includes a procedure for identifying edges that carry deterministic (point-mass) beliefs, prior to scheduling. This improves the scheduling for free energy evaluation, because it allows for longer deterministic branches to be present in the model.