### PR TITLE
Added PF reset to FactorGraph constructor.

### DIFF
--- a/src/algorithms/posterior_factorization.jl
+++ b/src/algorithms/posterior_factorization.jl
@@ -4,6 +4,8 @@ PosteriorFactorization,
 currentPosteriorFactorization, 
 setCurrentPosteriorFactorization
 
+global current_posterior_factorization = nothing
+
 mutable struct PosteriorFactorization
     graph::FactorGraph
     posterior_factors::Dict{Symbol, PosteriorFactor}
@@ -25,11 +27,7 @@ end
 Return currently active `PosteriorFactorization`. Create one if there is none.
 """
 function currentPosteriorFactorization()
-    try
-        return current_posterior_factorization
-    catch
-        return PosteriorFactorization()
-    end
+    current_posterior_factorization === nothing ? PosteriorFactorization() : current_posterior_factorization
 end
 
 function setCurrentPosteriorFactorization(pfz::PosteriorFactorization)

--- a/src/factor_graph.jl
+++ b/src/factor_graph.jl
@@ -33,12 +33,16 @@ end
 
 setCurrentGraph(graph::FactorGraph) = global current_graph = graph
 
-FactorGraph() = setCurrentGraph(FactorGraph(Dict{Symbol, FactorNode}(),
+function FactorGraph() 
+    
+    global current_posterior_factorization = nothing
+    
+    setCurrentGraph(FactorGraph(Dict{Symbol, FactorNode}(),
                                             Edge[],
                                             Dict{Symbol, Variable}(),
                                             Dict{Type, Int}(),
                                             Dict{Clamp, Tuple{Symbol, Int}}()))
-
+end
 """
 Automatically generate a unique id based on the current counter value for the element type.
 """


### PR DESCRIPTION
Consider following script (adapted from the coin flip example from the demos):

```julia
using ForneyLab

############################################
# First model
############################################

g = FactorGraph()
b = [0.7, 0.3] # Prior probability vector
A = [0.2 0.9; 0.8 0.1] # Left-stochastic matrix for conditional probability

@RV m ~ Categorical(b) # Prior
@RV w ~ Transition(m, A) # Observation model

placeholder(w, :w, dims=(2,)); # Placeholder for observation

algo = messagePassingAlgorithm(m) # Build the algorithm code
source_code = algorithmSourceCode(algo)

############################################
# Alternative
############################################

g = FactorGraph()
d = [0.6, 0.4] # Prior probability vector
C = [0.2 0.9; 0.8 0.1] # Left-stochastic matrix for conditional probability

@RV r ~ Categorical(d) # Prior
@RV y ~ Transition(r, C) # Observation model

placeholder(y, :y, dims=(2,)); # Placeholder for observation

algo = messagePassingAlgorithm(r) # Build the algorithm code
source_code = algorithmSourceCode(algo)
```

If you then inspect the generated code for both of these, you can see that the `PosteriorFactorization` object from the first model is being used to generate MP algorithm for the second model:
```julia
function step!(data::Dict, marginals::Dict=Dict(), messages::Vector{Message}=Array{Message}(undef, 2))
    messages[1] = ruleSPCategoricalOutNP(nothing, Message(Multivariate, PointMass, m=[0.7, 0.3]))
    messages[2] = ruleSPTransitionIn1PNP(Message(Multivariate, PointMass, m=data[:w]), nothing, Message(MatrixVariate, PointMass, m=[0.2 0.9; 0.8 0.1]))
    
    marginals[:m] = messages[1].dist * messages[2].dist
    
    return marginals
    
end

function step!(data::Dict, marginals::Dict=Dict(), messages::Vector{Message}=Array{Message}(undef, 2))
    messages[1] = ruleSPCategoricalOutNP(nothing, Message(Multivariate, PointMass, m=[0.7, 0.3]))
    messages[2] = ruleSPTransitionIn1PNP(Message(Multivariate, PointMass, m=data[:w]), nothing, Message(MatrixVariate, PointMass, m=[0.2 0.9; 0.8 0.1]))
    
    marginals[:m] = messages[1].dist * messages[2].dist
    
    return marginals
end
```

In order to resolve this you need either to explicitly reset `current_posterior_factorization` before constructing the second algorithm or reset it with each `FactorGraph()` call. For me the first option feels a bit awkward inside the same script (as the first call to `messagePassingAlgorithm()` doesn't require it and it becomes yet another thing you need to keep in mind). The invalidation of `current_posterior_factorization` seems like a decent solution to the problem. This PR implements it.