### PR TITLE
Extension of Multiplication node

### DIFF
--- a/src/engines/julia/update_rules/multiplication.jl
+++ b/src/engines/julia/update_rules/multiplication.jl
@@ -5,7 +5,12 @@ ruleSPMultiplicationOutNPP,
 ruleSPMultiplicationIn1GNP,
 ruleSPMultiplicationIn1PNP,
 ruleSPMultiplicationAGPN,
-ruleSPMultiplicationAPPN
+ruleSPMultiplicationAPPN,
+ruleSPMultiplicationOutNPΓ,
+ruleSPMultiplicationOutNΓP,
+ruleSPMultiplicationIn1ΓNP,
+ruleSPMultiplicationAΓPN
+
 
 
 #-------------------------------
@@ -47,6 +52,26 @@ ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Univariate}, msg_in1::Not
 ruleSPMultiplicationAPPN(msg_out::Message{PointMass, Univariate}, msg_in1::Message{PointMass, Univariate}, msg_a::Nothing) =
     Message(Univariate, PointMass, m=msg_out.dist.params[:m]/msg_in1.dist.params[:m])
 
+function ruleSPMultiplicationOutNPΓ(msg_out::Nothing,
+                                    msg_in1::Message{PointMass, Univariate},
+                                    msg_a::Message{Gamma})
+
+    Message(Univariate, Gamma, a=msg_a.dist.params[:a], b=msg_a.dist.params[:b]/msg_in1.dist.params[:m])
+end
+
+ruleSPMultiplicationOutNΓP(msg_out::Nothing, msg_in1::Message{Gamma}, msg_a::Message{PointMass, Univariate}) =
+    ruleSPMultiplicationOutNPΓ(nothing, msg_a, msg_in1)
+
+function ruleSPMultiplicationIn1ΓNP(msg_out::Message{Gamma},
+                                    msg_in1::Nothing,
+                                    msg_a::Message{PointMass, Univariate})
+
+
+    Message(Univariate, Gamma, a=msg_out.dist.params[:a], b=msg_out.dist.params[:b]*msg_a.dist.params[:m])
+end
+
+ruleSPMultiplicationAΓPN(msg_out::Message{Gamma}, msg_in1::Message{PointMass, Univariate}, msg_a::Nothing) =
+    ruleSPMultiplicationIn1ΓNP(msg_out, nothing, msg_in1)
 
 #------------------------------------------------------
 # MatrixVariate*multivariate (in1 and a do NOT commute)
@@ -91,7 +116,7 @@ ruleSPMultiplicationIn1PNP(msg_out::Message{PointMass, Multivariate}, msg_in1::N
 # Namely, Ax = y, where A ∈ R^{nx1}, x ∈ R^1, and y ∈ R^n. In this case, the matrix A
 # can be represented by a n-dimensional vector, and x by a scalar. Before computation,
 # quantities are converted to their proper dimensions (see situational sketch below).
-# 
+#
 #     | a ~ Multivariate -> R^{nx1}
 #     v  out ~ Multivariate -> R^n
 # -->[x]-->

--- a/src/update_rules/multiplication.jl
+++ b/src/update_rules/multiplication.jl
@@ -32,3 +32,23 @@
                 :outbound_type => Message{PointMass},
                 :inbound_types => (Message{PointMass}, Message{PointMass}, Nothing),
                 :name          => SPMultiplicationAPPN)
+
+@sumProductRule(:node_type     => Multiplication,
+                :outbound_type => Message{Gamma},
+                :inbound_types => (Nothing, Message{Gamma}, Message{PointMass}),
+                :name          => SPMultiplicationOutNΓP)
+
+@sumProductRule(:node_type     => Multiplication,
+                :outbound_type => Message{Gamma},
+                :inbound_types => (Nothing, Message{PointMass}, Message{Gamma}),
+                :name          => SPMultiplicationOutNPΓ)
+
+@sumProductRule(:node_type     => Multiplication,
+                :outbound_type => Message{Gamma},
+                :inbound_types => (Message{Gamma}, Nothing, Message{PointMass}),
+                :name          => SPMultiplicationIn1ΓNP)
+
+@sumProductRule(:node_type     => Multiplication,
+                :outbound_type => Message{Gamma},
+                :inbound_types => (Message{Gamma}, Message{PointMass}, Nothing),
+                :name          => SPMultiplicationAΓPN)

--- a/src/update_rules/multiplication.jl
+++ b/src/update_rules/multiplication.jl
@@ -35,20 +35,20 @@
 
 @sumProductRule(:node_type     => Multiplication,
                 :outbound_type => Message{Gamma},
-                :inbound_types => (Nothing, Message{Gamma}, Message{PointMass}),
+                :inbound_types => (Nothing, Message{Union{Gamma, Wishart}}, Message{PointMass}),
                 :name          => SPMultiplicationOutNΓP)
 
 @sumProductRule(:node_type     => Multiplication,
                 :outbound_type => Message{Gamma},
-                :inbound_types => (Nothing, Message{PointMass}, Message{Gamma}),
+                :inbound_types => (Nothing, Message{PointMass}, Message{Union{Gamma, Wishart}}),
                 :name          => SPMultiplicationOutNPΓ)
 
 @sumProductRule(:node_type     => Multiplication,
                 :outbound_type => Message{Gamma},
-                :inbound_types => (Message{Gamma}, Nothing, Message{PointMass}),
+                :inbound_types => (Message{Union{Gamma, Wishart}}, Nothing, Message{PointMass}),
                 :name          => SPMultiplicationIn1ΓNP)
 
 @sumProductRule(:node_type     => Multiplication,
                 :outbound_type => Message{Gamma},
-                :inbound_types => (Message{Gamma}, Message{PointMass}, Nothing),
+                :inbound_types => (Message{Union{Gamma, Wishart}}, Message{PointMass}, Nothing),
                 :name          => SPMultiplicationAΓPN)

--- a/test/factor_nodes/test_multiplication.jl
+++ b/test/factor_nodes/test_multiplication.jl
@@ -3,7 +3,10 @@ module MultiplicationTest
 using Test
 using ForneyLab
 using ForneyLab: outboundType, isApplicable
-using ForneyLab: SPMultiplicationOutNGP, SPMultiplicationOutNPG, SPMultiplicationIn1GNP, SPMultiplicationAGPN, SPMultiplicationOutNPP, SPMultiplicationIn1PNP, SPMultiplicationAPPN
+using ForneyLab: SPMultiplicationOutNGP, SPMultiplicationOutNPG, SPMultiplicationIn1GNP, SPMultiplicationAGPN,
+                 SPMultiplicationOutNPP, SPMultiplicationIn1PNP, SPMultiplicationAPPN, SPMultiplicationOutNΓP,
+                 SPMultiplicationOutNPΓ, SPMultiplicationIn1ΓNP, SPMultiplicationAΓPN
+
 
 @testset "Multiplication node construction through * syntax" begin
     g = FactorGraph()
@@ -22,6 +25,12 @@ using ForneyLab: SPMultiplicationOutNGP, SPMultiplicationOutNPG, SPMultiplicatio
     g = FactorGraph()
     @RV x ~ GaussianMeanVariance(constant(0.0), constant(1.0))
     @RV z = x*1.0
+    @test isa(z, Variable)
+    @test isa(g.nodes[:multiplication_1], Multiplication)
+
+    g = FactorGraph()
+    @RV x ~ Gamma(constant(1.0), constant(1.0))
+    @RV z = x*2.0
     @test isa(z, Variable)
     @test isa(g.nodes[:multiplication_1], Multiplication)
 end
@@ -91,6 +100,42 @@ end
     @test isApplicable(SPMultiplicationAPPN, [Message{PointMass}, Message{PointMass}, Nothing])
 
     @test ruleSPMultiplicationAPPN(Message(Univariate, PointMass, m=1.0), Message(Univariate, PointMass, m=2.0), nothing) == Message(Univariate, PointMass, m=0.5)
+end
+
+@testset "SPMultiplicationOutNPΓ" begin
+    @test SPMultiplicationOutNPΓ <: SumProductRule{Multiplication}
+
+    @test outboundType(SPMultiplicationOutNPΓ) == Message{Gamma}
+    @test isApplicable(SPMultiplicationOutNPΓ, [Nothing, Message{PointMass}, Message{Gamma}])
+
+    @test ruleSPMultiplicationOutNPΓ(nothing, Message(Univariate, PointMass, m=2.0), Message(Univariate, Gamma, a=1.0, b=2.0)) == Message(Gamma, a=1.0, b=1.0)
+end
+
+@testset "SPMultiplicationOutNΓP" begin
+    @test SPMultiplicationOutNΓP <: SumProductRule{Multiplication}
+
+    @test outboundType(SPMultiplicationOutNΓP) == Message{Gamma}
+    @test isApplicable(SPMultiplicationOutNΓP, [Nothing, Message{Gamma}, Message{PointMass}])
+
+    @test ruleSPMultiplicationOutNΓP(nothing, Message(Univariate, Gamma, a=1.0, b=2.0), Message(Univariate, PointMass, m=2.0)) == Message(Gamma, a=1.0, b=1.0)
+end
+
+@testset "SPMultiplicationIn1ΓNP" begin
+    @test SPMultiplicationIn1ΓNP <: SumProductRule{Multiplication}
+
+    @test outboundType(SPMultiplicationIn1ΓNP) == Message{Gamma}
+    @test isApplicable(SPMultiplicationIn1ΓNP, [Message{Gamma}, Nothing, Message{PointMass}])
+
+    @test ruleSPMultiplicationIn1ΓNP( Message(Univariate, Gamma, a=1.0, b=2.0), nothing, Message(Univariate, PointMass, m=2.0)) == Message(Gamma, a=1.0, b=4.0)
+end
+
+@testset "SPMultiplicationAΓPN" begin
+    @test SPMultiplicationAΓPN <: SumProductRule{Multiplication}
+
+    @test outboundType(SPMultiplicationAΓPN) == Message{Gamma}
+    @test isApplicable(SPMultiplicationAΓPN, [Message{Gamma}, Message{PointMass}, Nothing])
+
+    @test ruleSPMultiplicationAΓPN( Message(Univariate, Gamma, a=1.0, b=2.0), Message(Univariate, PointMass, m=2.0), nothing) == Message(Gamma, a=1.0, b=4.0)
 end
 
 end # module

--- a/test/factor_nodes/test_multiplication.jl
+++ b/test/factor_nodes/test_multiplication.jl
@@ -138,4 +138,17 @@ end
     @test ruleSPMultiplicationAΓPN( Message(Univariate, Gamma, a=1.0, b=2.0), Message(Univariate, PointMass, m=2.0), nothing) == Message(Gamma, a=1.0, b=4.0)
 end
 
+@testset "messagePassingAlgorithm" begin
+    fg = FactorGraph()
+
+    @RV τ ~ Gamma(1, 1)
+    @RV x ~ GaussianMeanPrecision(0.0, 10*τ)
+    placeholder(x, :x)
+
+    q = PosteriorFactorization(τ, ids=[:T])
+    algo = messagePassingAlgorithm(free_energy=true)
+
+    @test isa(algo, InferenceAlgorithm)
+end
+
 end # module


### PR DESCRIPTION
This PR adds multiplication rules for `Message{Gamma}*Message{PointMass}`
```

    | a ~ PointMass
    v   out ~ Gamma
-->[x]-->
in1 ~ Gamma
```
The rules follow the scaling property of Gamma distribution.