### PR TITLE
Make FactorNode and Function prod symmetric

### DIFF
--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -175,7 +175,11 @@ end
     return prod!(x, y, z) # Return a SampleList
 end
 
-function sampleWeightsAndEntropy(x::ProbabilityDistribution{V, F}, y::ProbabilityDistribution) where {V<:VariateType, F<:FactorNode}
+function sampleWeightsAndEntropy(x::ProbabilityDistribution{V,F}, y::ProbabilityDistribution) where {V<:VariateType, F<:Function}
+    sampleWeightsAndEntropy(y, x)
+end
+
+function sampleWeightsAndEntropy(x::ProbabilityDistribution, y::ProbabilityDistribution)
     n_samples = default_n_samples # Number of samples is fixed
     samples = sample(x, n_samples)
 
@@ -197,10 +201,10 @@ function sampleWeightsAndEntropy(x::ProbabilityDistribution{V, F}, y::Probabilit
 end
 
 # General product definition that returns a SampleList
-@symmetrical function prod!(
-    x::ProbabilityDistribution{V, F},
+function prod!(
+    x::ProbabilityDistribution{V},
     y::ProbabilityDistribution{V},
-    z::ProbabilityDistribution{V, SampleList} = ProbabilityDistribution(V, SampleList, s=[0.0], w=[1.0])) where {V<:VariateType, F<:FactorNode}
+    z::ProbabilityDistribution{V, SampleList} = ProbabilityDistribution(V, SampleList, s=[0.0], w=[1.0])) where {V<:VariateType}
 
     (samples, weights, entropy) = sampleWeightsAndEntropy(x, y)
 

--- a/src/probability_distribution.jl
+++ b/src/probability_distribution.jl
@@ -106,8 +106,8 @@ slug(::Type{Function}) = "f"
 format(dist::ProbabilityDistribution{V, Function}) where V<:VariateType = "$(dist.params)"
 
 # Distribution constructors
-ProbabilityDistribution(::Type{V}, ::Type{Function}; kwargs...) where V<:VariateType = ProbabilityDistribution{V, Function}(kwargs)
-ProbabilityDistribution(::Type{Function}; kwargs...) = ProbabilityDistribution{Univariate, Function}(kwargs)
+ProbabilityDistribution(::Type{V}, ::Type{Function}; kwargs...) where V<:VariateType = ProbabilityDistribution{V, Function}(Dict{Symbol,Any}(kwargs))
+ProbabilityDistribution(::Type{Function}; kwargs...) = ProbabilityDistribution{Univariate, Function}(Dict{Symbol,Any}(kwargs))
 
 unsafeMode(dist::ProbabilityDistribution{T, Function}) where T<:VariateType = deepcopy(dist.params[:mode])
 


### PR DESCRIPTION
prod function of FactorNode and Function messages were defined only for prod(FactorNode, Function). This implementation allows prod(Function, FactorNode) to be handled as well.