### PR TITLE
Refactor user interface for EP update specification

### DIFF
--- a/demo/expectation_propagation.ipynb
+++ b/demo/expectation_propagation.ipynb
@@ -36,12 +36,13 @@
    "outputs": [],
    "source": [
     "using SpecialFunctions\n",
+    "using StatsFuns\n",
     "using Random\n",
+    "\n",
     "# Generate data set\n",
     "\n",
     "Random.seed!(123)\n",
     "n_samples = 40\n",
-    "Φ(x) = 0.5 + 0.5*erf.(x./sqrt(2))\n",
     "\n",
     "u_data = 0.1\n",
     "x_data = []\n",
@@ -49,7 +50,7 @@
     "x_prev = -2.0\n",
     "for t=1:n_samples\n",
     "    push!(x_data, x_prev + u_data + sqrt(0.01)*randn()) # State transition\n",
-    "    push!(y_data, Φ(x_data[end]) > rand()); # Observation\n",
+    "    push!(y_data, normcdf(x_data[end]) > rand()); # Observation\n",
     "    x_prev = x_data[end]\n",
     "end"
    ]
@@ -65,16 +66,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "┌ Info: Precompiling ForneyLab [9fc3f58a-c2cc-5bff-9419-6a294fefdca9]\n",
-      "└ @ Base loading.jl:1273\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "using ForneyLab\n",
     "\n",
@@ -115,7 +107,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "algo = messagePassingAlgorithm(x)\n",
+    "ep_sites = [(:probit_*t, :in1) for t=1:n_samples]\n",
+    "algo = messagePassingAlgorithm(x, ep_sites=ep_sites)\n",
     "source_code = algorithmSourceCode(algo);\n",
     "# println(source_code) # Uncomment to inspect algorithm code"
    ]

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -87,7 +87,7 @@ The name of an update rule is composed of several parts:
 5. `-`
 
 
-###### Example 3: `ruleEPProbitIn1GB`
+###### Example 3: `ruleEPProbitIn1BG`
 1. `rule`: update rule
 2. `EP`: expectation propagation algorithm
 3. `Probit`: probit factor node

--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -8,7 +8,7 @@ using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta, ga
 using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr
 using InteractiveUtils: subtypes
 using Printf: @sprintf
-using StatsFuns: logmvgamma, betainvcdf, gammainvcdf, poisinvcdf
+using StatsFuns: logmvgamma, betainvcdf, gammainvcdf, poisinvcdf, normlogcdf, normcdf
 using ForwardDiff
 using StatsBase: Weights
 using PositiveFactorizations

--- a/src/algorithms/expectation_propagation.jl
+++ b/src/algorithms/expectation_propagation.jl
@@ -7,20 +7,6 @@ A non-specific expectation propagation update
 """
 abstract type ExpectationPropagationRule{factor_type} <: MessageUpdateRule end
 
-"""
-Find default EP sites present in `node_set`
-"""
-function collectEPSites(node_set::Set{FactorNode})
-    ep_sites = Interface[]
-    for node in sort(collect(node_set))
-        if isa(node, Probit)
-            push!(ep_sites, node.i[:in1]) # EP site for a Probit node is i[:in1]
-        end
-    end
-
-    return ep_sites
-end
-
 messagePassingSchedule(variable::Variable) = messagePassingSchedule([variable])
 
 function inferUpdateRule!(entry::ScheduleEntry,
@@ -45,7 +31,7 @@ function inferUpdateRule!(entry::ScheduleEntry,
     if isempty(applicable_rules)
         error("No applicable $(rule_type) update for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
     elseif length(applicable_rules) > 1
-        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
+        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", ")): $(join(applicable_rules, ", "))")
     else
         entry.message_update_rule = first(applicable_rules)
     end

--- a/src/algorithms/joint_marginals.jl
+++ b/src/algorithms/joint_marginals.jl
@@ -45,7 +45,7 @@ function inferMarginalRule(cluster::Cluster, inbound_types::Vector{<:Type})
     if isempty(applicable_rules)
         error("No applicable marginal update rule for $(typeof(cluster.node)) node with inbound types: $(join(inbound_types, ", "))")
     elseif length(applicable_rules) > 1
-        error("Multiple applicable marginal update rules for $(typeof(cluster.node)) node with inbound types: $(join(inbound_types, ", "))")
+        error("Multiple applicable marginal update rules for $(typeof(cluster.node)) node with inbound types: $(join(inbound_types, ", ")): $(join(applicable_rules, ", "))")
     else
         marginal_update_rule = first(applicable_rules)
     end

--- a/src/algorithms/naive_variational_bayes.jl
+++ b/src/algorithms/naive_variational_bayes.jl
@@ -28,7 +28,7 @@ function inferUpdateRule!(  entry::ScheduleEntry,
     if isempty(applicable_rules)
         error("No applicable $(rule_type) update for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
     elseif length(applicable_rules) > 1
-        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
+        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", ")): $(join(applicable_rules, ", "))")
     else
         entry.message_update_rule = first(applicable_rules)
     end

--- a/src/algorithms/posterior_factorization.jl
+++ b/src/algorithms/posterior_factorization.jl
@@ -178,7 +178,12 @@ function setTargets!(pf::PosteriorFactor, pfz::PosteriorFactorization; target_va
         end
     end
 
-    # Determine which interfaces require breakers
+    # Determine breaker initialization for EP sites
+    for ep_site in pf.ep_sites
+        push!(pf.breaker_interfaces, ultimatePartner(ep_site))
+    end
+
+    # Determine which interfaces require breakers based on node-specific properties
     for edge in pf.internal_edges
         requiresBreaker(edge.a) && push!(pf.breaker_interfaces, edge.a)
         requiresBreaker(edge.b) && push!(pf.breaker_interfaces, edge.b)

--- a/src/algorithms/structured_variational_bayes.jl
+++ b/src/algorithms/structured_variational_bayes.jl
@@ -29,7 +29,7 @@ function inferUpdateRule!(entry::ScheduleEntry,
     if isempty(applicable_rules)
         error("No applicable $(rule_type) update for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
     elseif length(applicable_rules) > 1
-        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
+        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", ")): $(join(applicable_rules, ", "))")
     else
         entry.message_update_rule = first(applicable_rules)
     end

--- a/src/algorithms/sum_product.jl
+++ b/src/algorithms/sum_product.jl
@@ -75,7 +75,7 @@ function inferUpdateRule!(entry::ScheduleEntry,
             error("No applicable $(rule_type) update for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
         end
     elseif length(applicable_rules) > 1
-        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", "))")
+        error("Multiple applicable $(rule_type) updates for $(typeof(entry.interface.node)) node with inbound types: $(join(inbound_types, ", ")): $(join(applicable_rules, ", "))")
     else
         entry.message_update_rule = first(applicable_rules)
     end

--- a/src/factor_nodes/bernoulli.jl
+++ b/src/factor_nodes/bernoulli.jl
@@ -50,6 +50,8 @@ isProper(dist::ProbabilityDistribution{Univariate, Bernoulli}) = (0 <= dist.para
 
 unsafeMean(dist::ProbabilityDistribution{Univariate, Bernoulli}) = dist.params[:p]
 
+unsafeMode(dist::ProbabilityDistribution{Univariate, Bernoulli}) = round(dist.params[:p])
+
 unsafeMeanVector(dist::ProbabilityDistribution{Univariate, Bernoulli}) = [dist.params[:p], 1 - dist.params[:p]]
 
 unsafeVar(dist::ProbabilityDistribution{Univariate, Bernoulli}) = dist.params[:p]*(1 - dist.params[:p])

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -188,7 +188,7 @@ function sampleWeightsAndEntropy(x::ProbabilityDistribution, y::ProbabilityDistr
     log_samples_y = logPdf.([y], samples)
 
     # Extract the sample weights
-    w_raw = exp.(log_samples_y) # Unnormalized weights
+    w_raw = clamp.(exp.(log_samples_x), tiny, huge) # Unnormalized weights
     w_sum = sum(w_raw)
     weights = w_raw./w_sum # Normalize the raw weights
 

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -140,7 +140,10 @@ isProper(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = ab
     w_raw_x = exp.(log_samples_x)
     w_prod = w_raw_x.*y.params[:w]
     weights = w_prod./sum(w_prod) # Normalize weights
-
+    if any(isnan, weights) # Failsafe
+        weights = ones(n_samples)./n_samples
+    end
+    
     # Resample if required
     n_eff = 1/sum(weights.^2) # Effective number of particles
     if n_eff < n_samples/10

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -137,12 +137,9 @@ isProper(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = ab
     log_samples_x = logPdf.([x], samples)
 
     # Compute sample weights
-    w_raw_x = exp.(log_samples_x)
+    w_raw_x = clamp.(exp.(log_samples_x), tiny, huge)
     w_prod = w_raw_x.*y.params[:w]
     weights = w_prod./sum(w_prod) # Normalize weights
-    if any(isnan, weights) # Failsafe
-        weights = ones(n_samples)./n_samples
-    end
     
     # Resample if required
     n_eff = 1/sum(weights.^2) # Effective number of particles

--- a/src/update_rules/probit.jl
+++ b/src/update_rules/probit.jl
@@ -3,20 +3,25 @@
                 :inbound_types => (Nothing, Message{Gaussian}),
                 :name          => SPProbitOutNG)
 
+@sumProductRule(:node_type     => Probit,
+                :outbound_type => Message{Function},
+                :inbound_types => (Message{PointMass}, Nothing),
+                :name          => SPProbitIn1PN)
+
 @expectationPropagationRule(:node_type     => Probit,
                             :outbound_type => Message{GaussianWeightedMeanPrecision},
                             :inbound_types => (Message{Bernoulli}, Message{Gaussian}),
                             :outbound_id   => 2,
-                            :name          => EPProbitIn1GB)
+                            :name          => EPProbitIn1BG)
 
 @expectationPropagationRule(:node_type     => Probit,
                             :outbound_type => Message{GaussianWeightedMeanPrecision},
                             :inbound_types => (Message{Categorical}, Message{Gaussian}),
                             :outbound_id   => 2,
-                            :name          => EPProbitIn1GC)
+                            :name          => EPProbitIn1CG)
 
 @expectationPropagationRule(:node_type     => Probit,
                             :outbound_type => Message{GaussianWeightedMeanPrecision},
                             :inbound_types => (Message{PointMass}, Message{Gaussian}),
                             :outbound_id   => 2,
-                            :name          => EPProbitIn1GP)
+                            :name          => EPProbitIn1PG)

--- a/test/engines/test_message_passing_assemblers.jl
+++ b/test/engines/test_message_passing_assemblers.jl
@@ -49,6 +49,7 @@ end
     placeholder(y, :y)
     pfz = PosteriorFactorization()
     pf = PosteriorFactor(fg)
+    pf.ep_sites = Set{Interface}([fg.nodes[:probit_1].i[:in1]])
     setTargets!(pf, pfz, target_variables=Set{Variable}([x]))
     pf.schedule = messagePassingSchedule(pf)
     algo = InferenceAlgorithm(pfz)
@@ -56,7 +57,7 @@ end
     algo.interface_to_schedule_entry = ForneyLab.interfaceToScheduleEntry(algo)
     assembleSchedule!(pf)
     assembleInitialization!(pf)
-    @test pf.schedule[5].message_update_rule == ForneyLab.EPProbitIn1GP
+    @test pf.schedule[5].message_update_rule == ForneyLab.EPProbitIn1PG
     @test pf.schedule[3].initialize
 
     # Nonlinear

--- a/test/factor_nodes/test_probit.jl
+++ b/test/factor_nodes/test_probit.jl
@@ -3,7 +3,8 @@ module ProbitTest
 using Test
 using ForneyLab
 using ForneyLab: outboundType, isApplicable, requiresBreaker, breakerParameters
-using ForneyLab: SPProbitOutNG, EPProbitIn1GB, EPProbitIn1GC, EPProbitIn1GP
+using ForneyLab: SPProbitOutNG, SPProbitIn1PN, EPProbitIn1BG, EPProbitIn1CG, EPProbitIn1PG
+using StatsFuns: normcdf
 
 @testset "requiresBreaker and breakerParameters" begin
     fg = FactorGraph()
@@ -15,7 +16,7 @@ using ForneyLab: SPProbitOutNG, EPProbitIn1GB, EPProbitIn1GC, EPProbitIn1GP
     @test !requiresBreaker(np.i[:out]) # Dangling
     @test !requiresBreaker(np.i[:in1])
     @test !requiresBreaker(ng.i[:m])
-    @test requiresBreaker(ng.i[:out])
+    @test !requiresBreaker(ng.i[:out]) # requiresBreaker not applicable for EP
 
     @test_throws Exception breakerParameters(np.i[:out])
     @test breakerParameters(ng.i[:out]) == (Message{GaussianMeanVariance, Univariate}, ())
@@ -32,39 +33,47 @@ end
     @test isApplicable(SPProbitOutNG, [Nothing, Message{Gaussian}]) 
     @test !isApplicable(SPProbitOutNG, [Message{Bernoulli}, Nothing])
 
-    @test ruleSPProbitOutNG(nothing, Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, Bernoulli, p=ForneyLab.Φ(1/sqrt(1+0.5)))
+    @test ruleSPProbitOutNG(nothing, Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, Bernoulli, p=normcdf(1/sqrt(1+0.5)))
 end
 
-@testset "EPProbitIn1GB" begin
-    @test EPProbitIn1GB <: ExpectationPropagationRule{Probit}
-    @test outboundType(EPProbitIn1GB) == Message{GaussianWeightedMeanPrecision}
-    @test isApplicable(EPProbitIn1GB, [Message{Bernoulli}, Message{Gaussian}], 2) 
-    @test !isApplicable(EPProbitIn1GB, [Message{PointMass}, Message{Gaussian}], 2)
+@testset "SPProbitIn1PN" begin
+    @test SPProbitIn1PN <: SumProductRule{Probit}
+    @test outboundType(SPProbitIn1PN) == Message{Function}
+    @test isApplicable(SPProbitIn1PN, [Message{PointMass}, Nothing]) 
 
-    @test ruleEPProbitIn1GB(Message(Univariate, Bernoulli, p=1.0), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.6723616582693994, w=0.3295003993960708)
-    @test ruleEPProbitIn1GB(Message(Univariate, Bernoulli, p=0.8), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.4270174959448596, w=0.19914199922339604)
-    @test ruleEPProbitIn1GB(Message(Univariate, Bernoulli, p=0.5), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=4e-12, w=4e-12)
+    @test isa(ruleSPProbitIn1PN(Message(Univariate, PointMass, m=1.0), nothing), Message{Function, Univariate})
 end
 
-@testset "EPProbitIn1GC" begin
-    @test EPProbitIn1GC <: ExpectationPropagationRule{Probit}
-    @test outboundType(EPProbitIn1GC) == Message{GaussianWeightedMeanPrecision}
-    @test isApplicable(EPProbitIn1GC, [Message{Categorical}, Message{Gaussian}], 2) 
-    @test !isApplicable(EPProbitIn1GC, [Message{PointMass}, Message{Gaussian}], 2)
+@testset "EPProbitIn1BG" begin
+    @test EPProbitIn1BG <: ExpectationPropagationRule{Probit}
+    @test outboundType(EPProbitIn1BG) == Message{GaussianWeightedMeanPrecision}
+    @test isApplicable(EPProbitIn1BG, [Message{Bernoulli}, Message{Gaussian}], 2) 
+    @test !isApplicable(EPProbitIn1BG, [Message{PointMass}, Message{Gaussian}], 2)
 
-    @test ruleEPProbitIn1GC(Message(Univariate, Categorical, p=[1.0, 0.0]), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.6723616582693994, w=0.3295003993960708)
-    @test ruleEPProbitIn1GC(Message(Univariate, Categorical, p=[0.8, 0.2]), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.4270174959448596, w=0.19914199922339604)
-    @test ruleEPProbitIn1GC(Message(Univariate, Categorical, p=[0.5, 0.5]), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=4e-12, w=4e-12)
+    @test ruleEPProbitIn1BG(Message(Univariate, Bernoulli, p=1.0), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.6723616582693994, w=0.3295003993960708)
+    @test ruleEPProbitIn1BG(Message(Univariate, Bernoulli, p=0.8), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.4270174959448596, w=0.19914199922339604)
+    @test ruleEPProbitIn1BG(Message(Univariate, Bernoulli, p=0.5), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=4e-12, w=4e-12)
 end
 
-@testset "EPProbitIn1GP" begin
-    @test EPProbitIn1GP <: ExpectationPropagationRule{Probit}
-    @test outboundType(EPProbitIn1GP) == Message{GaussianWeightedMeanPrecision}
-    @test isApplicable(EPProbitIn1GP, [Message{PointMass}, Message{Gaussian}], 2) 
-    @test !isApplicable(EPProbitIn1GP, [Message{Bernoulli}, Message{Gaussian}], 2) 
+@testset "EPProbitIn1CG" begin
+    @test EPProbitIn1CG <: ExpectationPropagationRule{Probit}
+    @test outboundType(EPProbitIn1CG) == Message{GaussianWeightedMeanPrecision}
+    @test isApplicable(EPProbitIn1CG, [Message{Categorical}, Message{Gaussian}], 2) 
+    @test !isApplicable(EPProbitIn1CG, [Message{PointMass}, Message{Gaussian}], 2)
 
-    @test ruleEPProbitIn1GP(Message(Univariate, PointMass, m=true), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.6723616582693994, w=0.3295003993960708)
-    @test ruleEPProbitIn1GP(Message(Univariate, PointMass, m=NaN), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=4e-12, w=4e-12)
+    @test ruleEPProbitIn1CG(Message(Univariate, Categorical, p=[1.0, 0.0]), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.6723616582693994, w=0.3295003993960708)
+    @test ruleEPProbitIn1CG(Message(Univariate, Categorical, p=[0.8, 0.2]), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.4270174959448596, w=0.19914199922339604)
+    @test ruleEPProbitIn1CG(Message(Univariate, Categorical, p=[0.5, 0.5]), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=4e-12, w=4e-12)
+end
+
+@testset "EPProbitIn1PG" begin
+    @test EPProbitIn1PG <: ExpectationPropagationRule{Probit}
+    @test outboundType(EPProbitIn1PG) == Message{GaussianWeightedMeanPrecision}
+    @test isApplicable(EPProbitIn1PG, [Message{PointMass}, Message{Gaussian}], 2) 
+    @test !isApplicable(EPProbitIn1PG, [Message{Bernoulli}, Message{Gaussian}], 2) 
+
+    @test ruleEPProbitIn1PG(Message(Univariate, PointMass, m=true), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=0.6723616582693994, w=0.3295003993960708)
+    @test ruleEPProbitIn1PG(Message(Univariate, PointMass, m=NaN), Message(Univariate, GaussianMeanVariance, m=1.0, v=0.5)) == Message(Univariate, GaussianWeightedMeanPrecision, xi=4e-12, w=4e-12)
 end
 
 @testset "averageEnergy" begin


### PR DESCRIPTION
This PR refactors the user interface for specification of EP-sites. Previously, EP-sites were automatically assigned based on node type (e.g. `Probit`). However, other types message updates (e.g. sum-product) might also be available. The current interface for algorithm specification requires the user to explicitly pass `ep_sites` at the time of construction.