### PR TITLE
Optional variate type specification for updates around Nonlinear node

### DIFF
--- a/src/engines/julia/update_rules/nonlinear_sampling.jl
+++ b/src/engines/julia/update_rules/nonlinear_sampling.jl
@@ -62,7 +62,7 @@ end
 
 function ruleSPNonlinearSInGX(g::Function,
                               inx::Int64, # Index of inbound interface inx
-                              msg_out::Message{<:Gaussian, V},
+                              msg_out::Message{<:FactorFunction, V},
                               msgs_in::Vararg{Message{<:Gaussian, V}};
                               n_samples=default_n_samples,
                               variate=V) where V<:VariateType
@@ -93,7 +93,7 @@ function ruleSPNonlinearSInGX(g::Function,
 end
 
 function ruleMNonlinearSInGX(g::Function,
-                             msg_out::Message{<:Gaussian, V},
+                             msg_out::Message{<:FactorFunction, V},
                              msgs_in::Vararg{Message{<:Gaussian, V}}) where V<:VariateType
 
     # Extract joint statistics of inbound messages

--- a/src/update_rules/nonlinear_sampling.jl
+++ b/src/update_rules/nonlinear_sampling.jl
@@ -30,8 +30,12 @@ function isApplicable(::Type{SPNonlinearSInGX}, input_types::Vector{<:Type})
     (input_types[1] != Nothing) || return false
 
     nothing_inputs = 0
+    factorfunction_input = false
     gaussian_inputs = 0
-    for input_type in input_types
+    if matches(input_types[1], Message{FactorFunction})
+        factorfunction_input = true
+    end
+    for input_type in input_types[2:end]
         if input_type == Nothing
             nothing_inputs += 1
         elseif matches(input_type, Message{Gaussian})
@@ -39,7 +43,7 @@ function isApplicable(::Type{SPNonlinearSInGX}, input_types::Vector{<:Type})
         end
     end
 
-    return (nothing_inputs == 1) && (gaussian_inputs == total_inputs-1)
+    return (nothing_inputs == 1) && (gaussian_inputs == total_inputs-2) && factorfunction_input
 end
 
 mutable struct MNonlinearSInGX <: MarginalRule{Nonlinear{Sampling}} end


### PR DESCRIPTION
This PR addresses 2 issues:

- Sometimes the variate type of the outgoing message doesn't match the variate type(s) of incoming message(s). This PR adds the functionality to optionally specify outgoing message variate type. Default behaviour remains unchanged.
- Update rule for multi-Gaussian input case was too restrictive in the type of messages on interface `:out`. This PR relaxes this restriction.