### PR TITLE
A more universal entropy calculation method for sampling based inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.11.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -18,9 +19,9 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "1"
 Documenter = "0.25.2"
 ForwardDiff = "0.10.12"
 SpecialFunctions = "0.8.0, 0.10.3"
 StatsBase = "0.32.2, 0.33.1"
 StatsFuns = "0.9.5"
+julia = "1"

--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -11,6 +11,7 @@ using Printf: @sprintf
 using StatsFuns: logmvgamma, betainvcdf, gammainvcdf, poisinvcdf
 using ForwardDiff
 using StatsBase: Weights
+using DataStructures: Queue, enqueue!, dequeue!
 
 import Statistics: mean, var, cov
 import Base: +, -, *, ^, ==, exp, convert, show, prod!

--- a/src/engines/julia/update_rules/nonlinear_sampling.jl
+++ b/src/engines/julia/update_rules/nonlinear_sampling.jl
@@ -124,7 +124,7 @@ function ruleSPNonlinearSInGX(g::Function,
                               msgs_in::Vararg{Message{<:Gaussian, <:VariateType}};
                               n_samples=default_n_samples,
                               variate)
-    msgSPNonlinearSInGX(g, inx, msg_out, msg_in..., n_samples=n_samples, variate=variate)
+    msgSPNonlinearSInGX(g, inx, msg_out, msgs_in..., n_samples=n_samples, variate=variate)
 end
 
 function msgSPNonlinearSOutNFactorX(g::Function,

--- a/src/engines/julia/update_rules/nonlinear_sampling.jl
+++ b/src/engines/julia/update_rules/nonlinear_sampling.jl
@@ -94,10 +94,11 @@ function msgSPNonlinearSInGX(g::Function,
 
     # Compute joint belief on in's by gradient ascent
     m_in = gradientOptimization(log_joint, d_log_joint, m_fw_in, 0.01)
-    W_in = -ForwardDiff.jacobian(d_log_joint, m_in)
+    V_in = cholinv(-ForwardDiff.jacobian(d_log_joint, m_in))
 
     # Marginalize joint belief on in's
-    (m_inx, W_inx) = marginalizeGaussianMV(variate, m_in, W_in, ds, inx) # Marginalization is overloaded on VariateType V
+    (m_inx, V_inx) = marginalizeGaussianMV(variate, m_in, V_in, ds, inx) # Marginalization is overloaded on VariateType V
+    W_inx = cholinv(V_inx) # Convert to canonical statistics
     xi_inx = W_inx*m_inx
 
     # Divide marginal on inx by forward message

--- a/src/engines/julia/update_rules/nonlinear_sampling.jl
+++ b/src/engines/julia/update_rules/nonlinear_sampling.jl
@@ -345,6 +345,7 @@ function gradientOptimization(log_joint::Function, d_log_joint::Function, m_init
     m_old = m_initial
     satisfied = false
     step_count = 0
+    m_latests = if dim_tot == 1 Queue{Float64}() else Queue{Vector}() end
 
     while !satisfied
         m_new = m_old .+ step_size.*d_log_joint(m_old)
@@ -360,12 +361,13 @@ function gradientOptimization(log_joint::Function, d_log_joint::Function, m_init
             m_new = m_old .+ step_size.*d_log_joint(m_old)
         end
         step_count += 1
-        m_total .+= m_old
-        m_average = m_total ./ step_count
+        enqueue!(m_latests, m_old)
         if step_count > 10
+            m_average = sum(x for x in m_latests)./10
             if sum(sqrt.(((m_new.-m_average)./m_average).^2)) < dim_tot*0.1
                 satisfied = true
             end
+            dequeue!(m_latests);
         end
         if step_count > dim_tot*250
             satisfied = true

--- a/src/engines/julia/update_rules/nonlinear_unscented.jl
+++ b/src/engines/julia/update_rules/nonlinear_unscented.jl
@@ -421,6 +421,33 @@ function concatenateGaussianMV(ms::Vector{Vector{Float64}}, Vs::Vector{<:Abstrac
     return (m, V, ds) # Return concatenated mean and covariance with original dimensions (for splitting)
 end
 
+# Concatenate multiple mixed statistics
+function concatenateGaussianMV(ms::Vector{Any}, Vs::Vector{Any})
+    # Extract dimensions
+    ds = [length(m_k) for m_k in ms]
+    d_in_tot = sum(ds)
+
+    # Initialize concatenated statistics
+    m = zeros(d_in_tot)
+    V = zeros(d_in_tot, d_in_tot)
+
+    # Construct concatenated statistics
+    d_start = 1
+    for k = 1:length(ms) # For each inbound statistic
+        d_end = d_start + ds[k] - 1
+        if ds[k] == 1
+            m[d_start] = ms[k]
+            V[d_start, d_start] = Vs[k]
+        else
+            m[d_start:d_end] = ms[k]
+            V[d_start:d_end, d_start:d_end] = Vs[k]
+        end
+        d_start = d_end + 1
+    end
+
+    return (m, V, ds) # Return concatenated mean and covariance with original dimensions (for splitting)
+end
+
 """
 Split a vector in chunks of lengths specified by ds.
 """

--- a/src/factor_nodes/sample_list.jl
+++ b/src/factor_nodes/sample_list.jl
@@ -132,9 +132,10 @@ isProper(dist::ProbabilityDistribution{V, SampleList}) where V<:VariateType = ab
     y::ProbabilityDistribution{V, SampleList},
     z::ProbabilityDistribution{V, SampleList}=ProbabilityDistribution(V, SampleList, s=[0.0], w=[1.0])) where V<:VariateType
 
-    logIntegrand = (samples) -> logPdf.([x], samples)
     if haskey(y.params, :logintegrand)
         logIntegrand = (samples) -> y.params[:logintegrand](samples) .+ logPdf.([x], samples)
+    else
+        logIntegrand = (samples) -> logPdf.([x], samples)
     end
 
     samples = y.params[:s]

--- a/test/factor_nodes/test_nonlinear_unscented.jl
+++ b/test/factor_nodes/test_nonlinear_unscented.jl
@@ -90,6 +90,7 @@ end
 @testset "concatenateGaussianMV" begin
     @test concatenateGaussianMV([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]) == ([1.0, 2.0, 3.0], Diagonal([4.0, 5.0, 6.0]), ones(Int64, 3))
     @test concatenateGaussianMV([[1.0], [2.0, 3.0]], [mat(4.0), Diagonal([5.0, 6.0])]) == ([1.0, 2.0, 3.0], [4.0 0.0 0.0; 0.0 5.0 0.0; 0.0 0.0 6.0], [1, 2])
+    @test concatenateGaussianMV([1.0, [2.0, 3.0]], [4.0, Diagonal([5.0, 6.0])]) == ([1.0, 2.0, 3.0], [4.0 0.0 0.0; 0.0 5.0 0.0; 0.0 0.0 6.0], [1, 2])
 end
 
 @testset "split" begin

--- a/test/factor_nodes/test_sample_list.jl
+++ b/test/factor_nodes/test_sample_list.jl
@@ -28,41 +28,45 @@ end
     @test unsafeCov(ProbabilityDistribution(MatrixVariate, SampleList, s=[eye(2), eye(2)], w=[0.5, 0.5])) == zeros(4,4)
 end
 
-@testset "prod!" begin
-    dist1 = ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)
-    dist2 = dist1 * ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.5, 0.5])
-    dist3 = ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.6224593312018546, 0.37754066879814546])
-    @test dist2.params[:s] == dist3.params[:s]
-    @test dist2.params[:w] == dist3.params[:w]
-    @test dist2.params[:logintegrand]([-0.7, 1.5]) == logPdf.([dist1],[-0.7, 1.5])
-    #@test ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.5, 0.5]) * ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.0], v=mat(1.0)) == ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.6224593312018546, 0.37754066879814546])
-    dist1 = ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.0], v=mat(1.0))
-    dist2 = ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.5, 0.5]) * dist1
-    dist3 = ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.6224593312018546, 0.37754066879814546])
-    @test dist2.params[:s] == dist3.params[:s]
-    @test dist2.params[:w] == dist3.params[:w]
-    @test dist2.params[:logintegrand]([[-0.7], [1.5]]) == logPdf.([dist1],[[-0.7], [1.5]])
+@testset "Univariate SampleList prod!" begin
+    dist_gaussian = ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)
+    dist_prod = dist_gaussian * ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.5, 0.5])
+    dist_true_prod = ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.6224593312018546, 0.37754066879814546])
+    
+    @test dist_prod.params[:s] == dist_true_prod.params[:s]
+    @test dist_prod.params[:w] == dist_true_prod.params[:w]
+    @test dist_prod.params[:logintegrand]([-0.7, 1.5]) == logPdf.([dist_gaussian],[-0.7, 1.5])
+end
+
+@testset "Multivariate SampleList prod!" begin
+    dist_gaussian = ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.0], v=mat(1.0))
+    dist_prod = dist_gaussian * ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.5, 0.5]) 
+    dist_true_prod = ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.6224593312018546, 0.37754066879814546])
+    
+    @test dist_prod.params[:s] == dist_true_prod.params[:s]
+    @test dist_prod.params[:w] == dist_true_prod.params[:w]
+    @test dist_prod.params[:logintegrand]([[-0.7], [1.5]]) == logPdf.([dist_gaussian],[[-0.7], [1.5]])
 end
 
 @testset "Initialization of logproposal, logintegrand, unnormalizedweights" begin
-    dist1 = ProbabilityDistribution(Univariate, Beta, a=2.0, b=1.0)
-    dist2 = ProbabilityDistribution(Univariate, Gamma, a=2.0, b=1.0)
-    dist3 = ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.5, 0.5])
-    dist4 = dist1*dist2
-    dist5 = dist2*dist3
-    dist6 = dist4*dist2
+    dist_beta = ProbabilityDistribution(Univariate, Beta, a=2.0, b=1.0)
+    dist_gamma = ProbabilityDistribution(Univariate, Gamma, a=2.0, b=1.0)
+    dist_sample = ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.5, 0.5])
+    dist_betagamma = dist_beta*dist_gamma
+    dist_gammasample = dist_gamma*dist_sample
+    dist_betagg = dist_betagamma*dist_gamma
 
-    @test haskey(dist4.params, :logproposal)
-    @test haskey(dist4.params, :logintegrand)
-    @test haskey(dist4.params, :unnormalizedweights)
+    @test haskey(dist_betagamma.params, :logproposal)
+    @test haskey(dist_betagamma.params, :logintegrand)
+    @test haskey(dist_betagamma.params, :unnormalizedweights)
 
-    @test !haskey(dist5.params, :logproposal)
-    @test haskey(dist5.params, :logintegrand)
-    @test !haskey(dist5.params, :unnormalizedweights)
+    @test !haskey(dist_gammasample.params, :logproposal)
+    @test haskey(dist_gammasample.params, :logintegrand)
+    @test !haskey(dist_gammasample.params, :unnormalizedweights)
 
-    @test haskey(dist6.params, :logproposal)
-    @test haskey(dist6.params, :logintegrand)
-    @test haskey(dist6.params, :unnormalizedweights)
+    @test haskey(dist_betagg.params, :logproposal)
+    @test haskey(dist_betagg.params, :logintegrand)
+    @test haskey(dist_betagg.params, :unnormalizedweights)
 end
 
 @testset "bootstrap" begin

--- a/test/factor_nodes/test_sample_list.jl
+++ b/test/factor_nodes/test_sample_list.jl
@@ -32,7 +32,7 @@ end
     dist_gaussian = ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)
     dist_prod = dist_gaussian * ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.5, 0.5])
     dist_true_prod = ProbabilityDistribution(Univariate, SampleList, s=[0.0, 1.0], w=[0.6224593312018546, 0.37754066879814546])
-    
+
     @test dist_prod.params[:s] == dist_true_prod.params[:s]
     @test dist_prod.params[:w] == dist_true_prod.params[:w]
     @test dist_prod.params[:logintegrand]([-0.7, 1.5]) == logPdf.([dist_gaussian],[-0.7, 1.5])
@@ -40,9 +40,9 @@ end
 
 @testset "Multivariate SampleList prod!" begin
     dist_gaussian = ProbabilityDistribution(Multivariate, GaussianMeanVariance, m=[0.0], v=mat(1.0))
-    dist_prod = dist_gaussian * ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.5, 0.5]) 
+    dist_prod = dist_gaussian * ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.5, 0.5])
     dist_true_prod = ProbabilityDistribution(Multivariate, SampleList, s=[[0.0], [1.0]], w=[0.6224593312018546, 0.37754066879814546])
-    
+
     @test dist_prod.params[:s] == dist_true_prod.params[:s]
     @test dist_prod.params[:w] == dist_true_prod.params[:w]
     @test dist_prod.params[:logintegrand]([[-0.7], [1.5]]) == logPdf.([dist_gaussian],[[-0.7], [1.5]])
@@ -143,6 +143,44 @@ end
     marginals = step!(Dict())
 
     @test marginals[:y] == ProbabilityDistribution(Univariate, SampleList, s=collect(1.0:4.0), w=ones(4)/4)
+end
+
+@testset "Differential Entropy estimate" begin
+    fg = FactorGraph()
+
+    @RV x ~ Gamma(3.4, 1.2)
+    @RV s1 ~ Nonlinear{Sampling}(x, g=g)
+    @RV y1 ~ Poisson(s1)
+    @RV y2 ~ Poisson(x)
+
+    @RV z ~ Gamma(3.4, 1.2)
+    @RV s2 ~ Nonlinear{Sampling}(z, g=g)
+    @RV y3 ~ Poisson(z)
+    @RV y4 ~ Poisson(s2)
+
+    @RV w ~ Gamma(3.4, 1.2)
+    @RV y5 ~ Poisson(w)
+    @RV y6 ~ Poisson(w)
+
+    placeholder(y1,:y1)
+    placeholder(y2,:y2)
+    placeholder(y3,:y3)
+    placeholder(y4,:y4)
+    placeholder(y5,:y5)
+    placeholder(y6,:y6)
+
+    pfz = PosteriorFactorization(fg)
+    algo = messagePassingAlgorithm([x,z,w])
+    source_code = algorithmSourceCode(algo)
+    eval(Meta.parse(source_code));
+
+    v_1, v_2 = 7, 5
+    data = Dict(:y1 => v_1, :y2 => v_2, :y3 => v_1, :y4 => v_2, :y5 => v_1, :y6 => v_2)
+    marginals = step!(data)
+
+    @test isapprox(marginals[:x].params[:entropy], differentialEntropy(marginals[:w]), atol=0.1)
+    @test isapprox(marginals[:z].params[:entropy], differentialEntropy(marginals[:w]), atol=0.1)
+
 end
 
 end


### PR DESCRIPTION
In the previous implementation of sampling based inference, the free energy calculation was not possible in smoothing tasks unless the hidden states are Gaussian distributed. With this PR, we generalise the entropy calculation to broader range of inference tasks such as smoothing in switching state space models where the forward messages, commute through equality nodes on the most upper chain, are constituted by SampleList. The entropy calculation is carried out by conveying the proposal distribution and integrand information on SampleList messages. When a SampleList message collides with a probability distribution or its pdf, our method updates the integrand. This allows entropy calculation not only for those cases where two probability distribution or pfd messages collide, i.e. m1(x).m2(x), but also for the cases when multiple collisions are required to approximate posteriors, e.g. q(x) \propto m1(x).m2(x).m3(x).m4(x).