### PR TITLE
Stability - improve log(det()) function

### DIFF
--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -5,7 +5,7 @@ using Base64: base64encode
 using LinearAlgebra: diag, det, tr, cholesky, pinv, PosDefException
 using SparseArrays: spzeros
 using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta, gamma, loggamma, erf
-using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr
+using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr, logdet
 using InteractiveUtils: subtypes
 using Printf: @sprintf
 using StatsFuns: logmvgamma, betainvcdf, gammainvcdf, poisinvcdf, normlogcdf, normcdf

--- a/src/ForneyLab.jl
+++ b/src/ForneyLab.jl
@@ -5,11 +5,7 @@ using Base64: base64encode
 using LinearAlgebra: diag, det, tr, cholesky, pinv, PosDefException
 using SparseArrays: spzeros
 using SpecialFunctions: digamma, erfc, logfactorial, logabsgamma, logabsbeta, gamma, loggamma, erf
-<<<<<<< HEAD
 using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr, logdet
-=======
-using LinearAlgebra: Diagonal, Hermitian, isposdef, ishermitian, I, tr, logdet
->>>>>>> 2bac467dbd6cd8a9d066f22e0cf140529644f37a
 using InteractiveUtils: subtypes
 using Printf: @sprintf
 using StatsFuns: logmvgamma, betainvcdf, gammainvcdf, poisinvcdf, normlogcdf, normcdf

--- a/src/factor_nodes/gaussian.jl
+++ b/src/factor_nodes/gaussian.jl
@@ -128,7 +128,7 @@ function differentialEntropy(dist::ProbabilityDistribution{Univariate, F}) where
 end
 
 function differentialEntropy(dist::ProbabilityDistribution{Multivariate, F}) where F<:Gaussian
-    return  0.5*log(det(unsafeCov(dist))) +
+    return  0.5*logdet(unsafeCov(dist)) +
             (dims(dist)/2)*log(2*pi) +
             (dims(dist)/2)
 end

--- a/src/factor_nodes/wishart.jl
+++ b/src/factor_nodes/wishart.jl
@@ -56,7 +56,7 @@ function unsafeDetLogMean(dist::ProbabilityDistribution{MatrixVariate, Wishart})
     d = dims(dist)[1]
     sum([digamma.(0.5*(dist.params[:nu] + 1 - i)) for i = 1:d]) +
     d*log(2) +
-    log(det(dist.params[:v]))
+    logdet(dist.params[:v])
 end
 
 function unsafeVar(dist::ProbabilityDistribution{MatrixVariate, Wishart}) # unsafe variance

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,4 +1,4 @@
-export huge, tiny, cholinv, logdet, diageye, eye, format, *, ^, mat, step!, init
+export huge, tiny, cholinv, diageye, eye, format, *, ^, mat, step!, init
 
 # Constants to define smallest/largest supported numbers.
 # Used for clipping quantities to ensure numerical stability.
@@ -26,25 +26,6 @@ Wrapper for `logabsbeta` function that returns first element of its output
 """
 function labsbeta(x::Number, y::Number)
     return logabsbeta(x, y)[1]
-end
-
-""""
-Numerically stable version of the log(det(...)) function which utilizes the eigenvalue decomposition.
-
-This version assumes the matrix to be positive definite.
-
-The numically stable version can be determined as follows:
-log(det(M))
-= log(det(Q*Λ*Q^{-1}))
-= log(det(Q) * det(Λ) * det(Q^{-1}))
-= log(det(Q) * det(Λ) / det(Q))
-= log(det(Λ))   # Λ is diagonal
-= log(prod(λi))
-= sum(log.(λi))
-
-"""
-function logdet(M::AbstractMatrix)
-    return sum(log.(eigvals(M)))
 end
 
 

--- a/src/probability_distribution.jl
+++ b/src/probability_distribution.jl
@@ -84,7 +84,7 @@ unsafeLogMean(dist::ProbabilityDistribution{Multivariate, PointMass}) = log.(cla
 unsafeLogMean(dist::ProbabilityDistribution{MatrixVariate, PointMass}) = log.(clamp.(dist.params[:m], tiny, Inf))
 
 unsafeDetLogMean(dist::ProbabilityDistribution{Univariate, PointMass}) = log(dist.params[:m])
-unsafeDetLogMean(dist::ProbabilityDistribution{MatrixVariate, PointMass}) = log(det(dist.params[:m]))
+unsafeDetLogMean(dist::ProbabilityDistribution{MatrixVariate, PointMass}) = logdet(dist.params[:m])
 
 unsafeMirroredLogMean(dist::ProbabilityDistribution{Univariate, PointMass}) = log(1.0 - dist.params[:m])
 


### PR DESCRIPTION
The log(det()) function can easily give an overflow or underflow. Therefore we refactor the code using the eigenvalue decomposition, preventing this issue. See issue for derivation of solution strategy.