### PR TITLE
Fix probit average energy

### DIFF
--- a/test/factor_nodes/test_probit.jl
+++ b/test/factor_nodes/test_probit.jl
@@ -77,8 +77,8 @@ end
 end
 
 @testset "averageEnergy" begin
-    @test averageEnergy(Probit, ProbabilityDistribution(Univariate, Bernoulli, p=1.0), ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)) == -1.291942516803335
-    @test averageEnergy(Probit, ProbabilityDistribution(Univariate, PointMass, m=1.0), ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)) == -1.291942516803335
+    @test averageEnergy(Probit, ProbabilityDistribution(Univariate, Bernoulli, p=1.0), ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)) == 1.0000000289419368
+    @test averageEnergy(Probit, ProbabilityDistribution(Univariate, PointMass, m=1.0), ProbabilityDistribution(Univariate, GaussianMeanVariance, m=0.0, v=1.0)) == 1.0000000289419368
 end
 
 end # module


### PR DESCRIPTION
The average energy calculation for the probit node is incorrect, as well as the tests. This pull request fixes the issue.

The average energy for a standard normal distribution at the input of the probit node, should always return 1. A detailed explanation can be found at https://math.stackexchange.com/questions/2342234/does-the-expectation-of-the-log-of-a-gaussian-cumulative-distribution-function-w.

The average energy calculation has been updated, as well as the corresponding tests.