### PR TITLE
Nonlinear fix

### DIFF
--- a/src/engines/julia/update_rules/nonlinear_sampling.jl
+++ b/src/engines/julia/update_rules/nonlinear_sampling.jl
@@ -273,16 +273,6 @@ function collectSumProductNodeInbounds(node::Nonlinear{Sampling}, entry::Schedul
         push!(inbounds, Dict{Symbol, Any}(:n_samples => node.n_samples,
                                           :keyword   => true))
     end
-    # # Message on out interface
-    # if (inx == 0) && (node.out_variate !== nothing)
-    #     push!(inbounds, Dict{Symbol, Any}(:variate => node.out_variate,
-    #                                       :keyword   => true))
-    # end
-    # # Message on in interface
-    # if (inx > 0) && (node.in_variates !== nothing)
-    #     push!(inbounds, Dict{Symbol, Any}(:variate => node.in_variates[inx],
-    #                                       :keyword   => true))
-    # end
     return inbounds
 end
 

--- a/src/engines/julia/update_rules/nonlinear_sampling.jl
+++ b/src/engines/julia/update_rules/nonlinear_sampling.jl
@@ -64,17 +64,10 @@ end
 
 function ruleSPNonlinearSOutNGX(g::Function,
                                 msg_out::Nothing,
-                                msgs_in::Vararg{Message{<:Gaussian, <:VariateType}};
-                                n_samples=default_n_samples,
-                                variate)
-    return msgSPNonlinearSOutNGX(g, msg_out, msgs_in..., n_samples=n_samples, variate=variate)
-end
-
-function ruleSPNonlinearSOutNGX(g::Function,
-                                msg_out::Nothing,
                                 msgs_in::Vararg{Message{<:Gaussian, V}};
-                                n_samples=default_n_samples) where V<:VariateType
-    return msgSPNonlinearSOutNGX(g, msg_out, msgs_in..., n_samples=n_samples, variate=V)
+                                n_samples=default_n_samples, variate=V) where V<:VariateType
+
+    return msgSPNonlinearSOutNGX(g, msg_out, msgs_in..., n_samples=n_samples, variate=variate)
 end
 
 function msgSPNonlinearSInGX(g::Function,

--- a/test/factor_nodes/test_nonlinear_sampling.jl
+++ b/test/factor_nodes/test_nonlinear_sampling.jl
@@ -171,7 +171,7 @@ end
     algo = messagePassingAlgorithm(y)
     code = algorithmSourceCode(algo)
     
-    @test occursin("ruleSPNonlinearSInGX(g, 2, messages[3], messages[2], messages[1], variate=Univariate)", code)
+    @test occursin("ruleSPNonlinearSInGX(g, Univariate, 2, messages[3], messages[2], messages[1])", code)
 end
 
 end # module


### PR DESCRIPTION
This PR addresses issue #166.
As keyword arguments do not participate in methods dispatch, some nonlinear rules were simply ignored by `ForneyLab`.
Together with @semihakbayrak and @ivan-bocharov, we decided to switch the keyword argument `variate` to the positional argument.