### PR TITLE
change `repeat` to `fill`

### DIFF
--- a/src/engines/julia/update_rules/delta_sampling.jl
+++ b/src/engines/julia/update_rules/delta_sampling.jl
@@ -103,7 +103,7 @@ function ruleSPDeltaSInMX(g::Function,
         samples_in = []
         for i=1:length(msgs_in)
             if i==inx
-                push!(samples_in, collect(Iterators.repeat([z], n_samples)))
+                push!(samples_in, fill(z, n_samples))
             else
                 push!(samples_in, sample(msgs_in[i].dist, n_samples))
             end


### PR DESCRIPTION
I wasn't sure if this meant to use `Iterators.repeated` or `repeat`, but it seemed to just mean `fill`.